### PR TITLE
Render options

### DIFF
--- a/Definition.cs
+++ b/Definition.cs
@@ -76,6 +76,10 @@ namespace MetaphysicsIndustries.Giza
 
         public IEnumerable<CharClassSubExpression> EnumerateCharClasses() => 
             Expr.EnumerateCharClasses();
+
+        // TODO: improvement: a proper Clone method, with parameters for
+        // changing name, directives, etc. That would make it easier to keep
+        // IsImported correct.
     }
 }
 

--- a/ImportTransform.cs
+++ b/ImportTransform.cs
@@ -6,8 +6,10 @@ namespace MetaphysicsIndustries.Giza
 {
     public class ImportTransform : IGrammarTransform
     {
-        public ImportTransform(IFileSource fileSource)
+        public ImportTransform(IFileSource fileSource=null)
         {
+            if (fileSource == null)
+                fileSource = new FileSource();
             _fileSource = fileSource;
         }
 

--- a/ImportTransform.cs
+++ b/ImportTransform.cs
@@ -103,7 +103,8 @@ namespace MetaphysicsIndustries.Giza
                 importRefs = importedDefsByName.Values.Select(
                     defToImport => new ImportRef
                     {
-                        SourceName = defToImport.Name, DestName = defToImport.Name
+                        SourceName = defToImport.Name,
+                        DestName = defToImport.Name
                     }).ToArray();
             }
 

--- a/MetaphysicsIndustries.Giza.Test/TokenizeTransformTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/TokenizeTransformTest.cs
@@ -675,6 +675,40 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsFalse(literal.IsSkippable);
             Assert.IsFalse(literal.IsRepeatable);
         }
+
+        [Test]
+        public void TestImportedStaysImported()
+        {
+            // given
+            var g = new Grammar
+            {
+                //def = 'value';
+                Definitions = new List<Definition>
+                {
+                    new Definition(
+                        name: "def",
+                        expr: new Expression(
+                            new LiteralSubExpression(value: "value")))
+                    {
+                        IsImported = true  // here's the important bit
+                    }
+                }
+            };
+            var tt = new TokenizeTransform();
+            // when
+            var result = tt.Tokenize(g);
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Definitions.Count);
+            var explicitDef = result.FindDefinitionByName("def");
+            Assert.IsNotNull(explicitDef);
+            Assert.IsTrue(explicitDef.IsImported); // still marked as imported
+            Assert.AreNotSame(explicitDef,g.Definitions[0]);
+            var implicitDef =
+                result.FindDefinitionByName("$implicit literal value");
+            Assert.IsNotNull(implicitDef);
+            Assert.IsTrue(implicitDef.IsImported); // should it be, though?
+        }
     }
 }
 

--- a/TokenizeTransform.cs
+++ b/TokenizeTransform.cs
@@ -172,8 +172,11 @@ namespace MetaphysicsIndustries.Giza
             Dictionary<CharClassSubExpression, Definition> defsByCharClass)
         {
             return new Definition(def.Name, def.Directives,
-                ReplaceInExpression(def.Expr, defsByLiteral, 
-                    defsByCharClass));
+                ReplaceInExpression(def.Expr, defsByLiteral,
+                    defsByCharClass))
+            {
+                IsImported = def.IsImported,
+            };
         }
 
         public Expression ReplaceInExpression(Expression expr,

--- a/giza/RenderReplCommand.cs
+++ b/giza/RenderReplCommand.cs
@@ -64,7 +64,6 @@ namespace giza
                     Type=ParameterType.String,
                     Description="Save the c# class to the specified file, instead of printing it out",
                 },
-                // TODO: add these new options to RenderCommand
                 new Option {
                     Name="base",
                     Type = ParameterType.String,


### PR DESCRIPTION
This PR adds additional `--base`, `--using`, and `--skip-imported` options to the `render` command. These options were previously added to the `render` repl command in #7 .

This PR also fixes a bug in `TokenizeTransform`, which caused imported definitions to lose their imported status.