### PR TITLE
Relative import

### DIFF
--- a/Definition.cs
+++ b/Definition.cs
@@ -37,7 +37,7 @@ namespace MetaphysicsIndustries.Giza
     {
         public Definition(string name = "",
             IEnumerable<DefinitionDirective> directives = null,
-            Expression expr = null)
+            Expression expr = null, bool isImported=false)
         {
             Name = name;
             if (directives != null)
@@ -48,6 +48,8 @@ namespace MetaphysicsIndustries.Giza
             if (expr == null)
                 expr = new Expression();
             Expr = expr;
+
+            IsImported = isImported;
         }
 
         public override string ToString() => $"Definition {Name}";
@@ -55,6 +57,7 @@ namespace MetaphysicsIndustries.Giza
         public string Name = string.Empty;
         public readonly HashSet<DefinitionDirective> Directives = new HashSet<DefinitionDirective>();
         public Expression Expr;
+        public bool IsImported { get; set; }
 
         public bool MindWhitespace => Directives.Contains(DefinitionDirective.MindWhitespace);
         public bool IgnoreCase => Directives.Contains(DefinitionDirective.IgnoreCase);
@@ -66,20 +69,28 @@ namespace MetaphysicsIndustries.Giza
             Directives.Contains(DefinitionDirective.Comment);
 
         public bool IsComment => Directives.Contains(DefinitionDirective.Comment);
-        public bool IsImported { get; set; } = false;
-        
-        public IEnumerable<DefRefSubExpression> EnumerateDefRefs() => 
+
+        public IEnumerable<DefRefSubExpression> EnumerateDefRefs() =>
             Expr.EnumerateDefRefs();
 
-        public IEnumerable<LiteralSubExpression> EnumerateLiterals() => 
+        public IEnumerable<LiteralSubExpression> EnumerateLiterals() =>
             Expr.EnumerateLiterals();
 
-        public IEnumerable<CharClassSubExpression> EnumerateCharClasses() => 
+        public IEnumerable<CharClassSubExpression> EnumerateCharClasses() =>
             Expr.EnumerateCharClasses();
 
-        // TODO: improvement: a proper Clone method, with parameters for
-        // changing name, directives, etc. That would make it easier to keep
-        // IsImported correct.
+        public Definition Clone(string newName=null,
+            IEnumerable<DefinitionDirective> newDirectives=null,
+            Expression newExpr=null, bool? newIsImported=null)
+        {
+            if (newName == null) newName = Name;
+            if (newDirectives == null) newDirectives = Directives;
+            if (newExpr == null) newExpr = Expr;
+            if (newIsImported == null) newIsImported = IsImported;
+
+            return new Definition(newName, newDirectives, newExpr,
+                newIsImported.Value);
+        }
     }
 }
 

--- a/Definition.cs
+++ b/Definition.cs
@@ -37,7 +37,8 @@ namespace MetaphysicsIndustries.Giza
     {
         public Definition(string name = "",
             IEnumerable<DefinitionDirective> directives = null,
-            Expression expr = null, bool isImported=false)
+            Expression expr = null, bool isImported=false,
+            string source=null)
         {
             Name = name;
             if (directives != null)
@@ -50,6 +51,8 @@ namespace MetaphysicsIndustries.Giza
             Expr = expr;
 
             IsImported = isImported;
+
+            Source = source;
         }
 
         public override string ToString() => $"Definition {Name}";
@@ -58,6 +61,7 @@ namespace MetaphysicsIndustries.Giza
         public readonly HashSet<DefinitionDirective> Directives = new HashSet<DefinitionDirective>();
         public Expression Expr;
         public bool IsImported { get; set; }
+        public string Source;
 
         public bool MindWhitespace => Directives.Contains(DefinitionDirective.MindWhitespace);
         public bool IgnoreCase => Directives.Contains(DefinitionDirective.IgnoreCase);
@@ -87,9 +91,10 @@ namespace MetaphysicsIndustries.Giza
             if (newDirectives == null) newDirectives = Directives;
             if (newExpr == null) newExpr = Expr;
             if (newIsImported == null) newIsImported = IsImported;
+            // should source be an option?
 
             return new Definition(newName, newDirectives, newExpr,
-                newIsImported.Value);
+                newIsImported.Value, Source);
         }
     }
 }

--- a/FileSource.cs
+++ b/FileSource.cs
@@ -8,5 +8,14 @@ namespace MetaphysicsIndustries.Giza
         {
             return File.ReadAllText(path: filename);
         }
+
+        public string CombinePath(string fromFile, string toFile)
+        {
+            var a1 = Path.GetFullPath(fromFile);
+            var a2 = Path.GetDirectoryName(a1);
+            var a3 = Path.Combine(a2, toFile);
+            var a4 = Path.GetFullPath(a3);
+            return a4;
+        }
     }
 }

--- a/Grammar.cs
+++ b/Grammar.cs
@@ -5,13 +5,36 @@ namespace MetaphysicsIndustries.Giza
 {
     public class Grammar
     {
-        public List<Definition> Definitions;
-        public List<ImportStatement> ImportStatements;
+        public Grammar(IEnumerable<Definition> definitions = null,
+            IEnumerable<ImportStatement> importStatements = null,
+            string source = null)
+        {
+            if (definitions != null) Definitions.AddRange(definitions);
+            if (importStatements != null)
+                ImportStatements.AddRange(importStatements);
+            Source = source;
+        }
+
+        public readonly List<Definition> Definitions = new List<Definition>();
+        public readonly List<ImportStatement> ImportStatements =
+            new List<ImportStatement>();
         public string Source;
 
         public Definition FindDefinitionByName(string name)
         {
             return Definitions.FirstOrDefault(def => def.Name == name);
+        }
+
+        public Grammar Clone(IEnumerable<Definition> newDefinitions=null,
+            IEnumerable<ImportStatement> newImportStatements=null,
+            string newSource=null)
+        {
+            if (newDefinitions == null) newDefinitions = Definitions;
+            if (newImportStatements == null)
+                newImportStatements = ImportStatements;
+            if (newSource == null) newSource = Source;
+
+            return new Grammar(newDefinitions, newImportStatements, newSource);
         }
     }
 }

--- a/Grammar.cs
+++ b/Grammar.cs
@@ -7,6 +7,7 @@ namespace MetaphysicsIndustries.Giza
     {
         public List<Definition> Definitions;
         public List<ImportStatement> ImportStatements;
+        public string Source;
 
         public Definition FindDefinitionByName(string name)
         {

--- a/IFileSource.cs
+++ b/IFileSource.cs
@@ -3,5 +3,6 @@ namespace MetaphysicsIndustries.Giza
     public interface IFileSource
     {
         string GetFileContents(string filename);
+        string CombinePath(string fromFile, string toFile);
     }
 }

--- a/ImportTransform.cs
+++ b/ImportTransform.cs
@@ -56,7 +56,8 @@ namespace MetaphysicsIndustries.Giza
 
             return new Grammar
             {
-                Definitions = defsByName.Values.ToList()
+                Definitions = defsByName.Values.ToList(),
+                Source = g.Source
             };
         }
 
@@ -73,7 +74,7 @@ namespace MetaphysicsIndustries.Giza
                 var content = fileSource.GetFileContents(fileToImport);
                 var errors2 = new List<Error>();
                 var ss = new SupergrammarSpanner();
-                var ig1 = ss.GetGrammar(content, errors2);
+                var ig1 = ss.GetGrammar(content, errors2, fileToImport);
                 errors.AddRange(errors2);
                 if (errors2.ContainsNonWarnings())
                     return null;

--- a/ImportTransform.cs
+++ b/ImportTransform.cs
@@ -130,8 +130,7 @@ namespace MetaphysicsIndustries.Giza
                 var sourceName = importRef.SourceName;
                 var sourceDef = importedDefsByName[sourceName];
                 var destName = importRef.DestName;
-                var destDef = new Definition(destName,
-                    sourceDef.Directives, sourceDef.Expr, true);
+                var destDef = sourceDef.Clone(destName, newIsImported: true);
                 defsToImport1.Add(destDef);
             }
 

--- a/ImportTransform.cs
+++ b/ImportTransform.cs
@@ -133,8 +133,7 @@ namespace MetaphysicsIndustries.Giza
                 var sourceDef = importedDefsByName[sourceName];
                 var destName = importRef.DestName;
                 var destDef = new Definition(destName,
-                    sourceDef.Directives, sourceDef.Expr);
-                destDef.IsImported = true;
+                    sourceDef.Directives, sourceDef.Expr, true);
                 defsToImport1.Add(destDef);
             }
 

--- a/ImportTransform.cs
+++ b/ImportTransform.cs
@@ -54,11 +54,7 @@ namespace MetaphysicsIndustries.Giza
                 }
             }
 
-            return new Grammar
-            {
-                Definitions = defsByName.Values.ToList(),
-                Source = g.Source
-            };
+            return g.Clone(defsByName.Values);
         }
 
         static Definition[] ImportDefinitions(

--- a/ImportTransform.cs
+++ b/ImportTransform.cs
@@ -55,7 +55,9 @@ namespace MetaphysicsIndustries.Giza
                 }
             }
 
-            return g.Clone(defsByName.Values);
+            var g2 = g.Clone(defsByName.Values);
+            g2.ImportStatements.Clear();
+            return g2;
         }
 
 

--- a/ImportTransform.cs
+++ b/ImportTransform.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace MetaphysicsIndustries.Giza
@@ -40,7 +41,7 @@ namespace MetaphysicsIndustries.Giza
             foreach (var importStmt in g.ImportStatements)
             {
                 var importedDefs = ImportDefinitions(importStmt, errors2,
-                    fileSource, importCache);
+                    fileSource, importCache, g.Source);
                 errors.AddRange(errors2);
                 if (errors2.ContainsNonWarnings())
                     // TODO: proper exception type, like ImportException
@@ -57,16 +58,23 @@ namespace MetaphysicsIndustries.Giza
             return g.Clone(defsByName.Values);
         }
 
+
         static Definition[] ImportDefinitions(
             ImportStatement importStmt, List<Error> errors,
-            IFileSource fileSource, ImportCache importCache)
+            IFileSource fileSource, ImportCache importCache, string source)
         {
             var fileToImport = importStmt.Filename;
+            if (!Path.IsPathRooted(importStmt.Filename) &&
+                !string.IsNullOrWhiteSpace(source))
+            {
+                fileToImport = fileSource.CombinePath(source,
+                    importStmt.Filename);
+            }
+
             var importRefs = importStmt.ImportRefs;
 
             if (!importCache.ContainsKey(fileToImport))
             {
-                // TODO: relative imports should be relative to the importing file.
                 var content = fileSource.GetFileContents(fileToImport);
                 var errors2 = new List<Error>();
                 var ss = new SupergrammarSpanner();

--- a/ImportTransform.cs
+++ b/ImportTransform.cs
@@ -69,6 +69,7 @@ namespace MetaphysicsIndustries.Giza
 
             if (!importCache.ContainsKey(fileToImport))
             {
+                // TODO: relative imports should be relative to the importing file.
                 var content = fileSource.GetFileContents(fileToImport);
                 var errors2 = new List<Error>();
                 var ss = new SupergrammarSpanner();

--- a/MetaphysicsIndustries.Giza.Test/CSharpPathTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/CSharpPathTest.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Giza.Test
+{
+    [TestFixture]
+    public class CSharpPathTest
+    {
+        [Test]
+        public void PosixLeadingSlashIsAbsolute()
+        {
+            // given
+            const string path = "/path/to/file";
+            // expect
+            Assert.IsTrue(Path.IsPathRooted(path));
+        }
+
+        [Test]
+        public void PosixNoLeadingSlashIsRelative()
+        {
+            // given
+            const string path = "path/to/file";
+            // expect
+            Assert.IsFalse(Path.IsPathRooted(path));
+        }
+
+        [Test]
+        public void PosixLeadingDotIsRelative()
+        {
+            // given
+            const string path = "./path/to/file";
+            // expect
+            Assert.IsFalse(Path.IsPathRooted(path));
+        }
+
+        [Test]
+        public void PosixLeadingDotsIsRelative()
+        {
+            // given
+            const string path = "../path/to/file";
+            // expect
+            Assert.IsFalse(Path.IsPathRooted(path));
+        }
+    }
+}

--- a/MetaphysicsIndustries.Giza.Test/CSharpPathTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/CSharpPathTest.cs
@@ -41,5 +41,19 @@ namespace MetaphysicsIndustries.Giza.Test
             // expect
             Assert.IsFalse(Path.IsPathRooted(path));
         }
+
+        [Test]
+        public void PosixCombineAbsoluteAndRelative()
+        {
+            // given
+            const string fromPath = "/path/to/file1.giza";
+            const string toPath = "../another/file2.giza";
+            // when
+            var a1 = Path.GetFullPath(fromPath);
+            var a2 = Path.Combine(a1, toPath);
+            var a3 = Path.GetFullPath(a2);
+            // then
+            Assert.AreEqual("/path/to/another/file2.giza", a3);
+        }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/DefinitionRendererTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/DefinitionRendererTest.cs
@@ -107,6 +107,9 @@ namespace MetaphysicsIndustries.Giza.Test
 
             Assert.AreEqual(input, result);
         }
+
+        // TODO: test C# output
+        // TODO: test imports
     }
 }
 

--- a/MetaphysicsIndustries.Giza.Test/DefinitionTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/DefinitionTest.cs
@@ -30,7 +30,8 @@ namespace MetaphysicsIndustries.Giza.Test
             };
             var expr = new Expression(new LiteralSubExpression("value"));
             // when
-            var result = new Definition("def1", directives, expr, true);
+            var result = new Definition("def1", directives, expr, true,
+                "source1");
             // then
             Assert.IsNotNull(result);
             Assert.AreEqual("def1", result.Name);
@@ -42,6 +43,7 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsNotNull(result.Expr);
             Assert.AreSame(expr, result.Expr);
             Assert.IsTrue(result.IsImported);
+            Assert.AreEqual("source1", result.Source);
         }
 
         [Test]

--- a/MetaphysicsIndustries.Giza.Test/DefinitionTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/DefinitionTest.cs
@@ -1,0 +1,221 @@
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Giza.Test
+{
+    [TestFixture]
+    public class DefinitionTest
+    {
+        [Test]
+        public void CreateYieldsNewObjectWithDefaultValues()
+        {
+            // when
+            var result = new Definition();
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual("", result.Name);
+            Assert.IsEmpty(result.Directives);
+            Assert.IsNotNull(result.Expr);
+            Assert.IsEmpty(result.Expr.Items);
+            Assert.IsFalse(result.IsImported);
+        }
+
+        [Test]
+        public void CreateWithParametersYieldsThoseValues()
+        {
+            // given
+            var directives = new[]
+            {
+                DefinitionDirective.Atomic,
+                DefinitionDirective.IgnoreCase
+            };
+            var expr = new Expression(new LiteralSubExpression("value"));
+            // when
+            var result = new Definition("def1", directives, expr, true);
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual("def1", result.Name);
+            Assert.IsNotEmpty(result.Directives);
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.Atomic));
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.IgnoreCase));
+            Assert.IsNotNull(result.Expr);
+            Assert.AreSame(expr, result.Expr);
+            Assert.IsTrue(result.IsImported);
+        }
+
+        [Test]
+        public void CloneWithNoArgsYieldsCopy()
+        {
+            // given
+            var directives = new[]
+            {
+                DefinitionDirective.Atomic,
+                DefinitionDirective.IgnoreCase
+            };
+            var expr = new Expression(new LiteralSubExpression("value"));
+            var def = new Definition("def1", directives, expr, true);
+            // when
+            var result = def.Clone();
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual("def1", result.Name);
+            Assert.IsNotEmpty(result.Directives);
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.Atomic));
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.IgnoreCase));
+            Assert.IsNotNull(result.Expr);
+            Assert.AreSame(expr, result.Expr);
+            Assert.IsTrue(result.IsImported);
+        }
+
+        [Test]
+        public void CloneWithNewNameYieldsCopyWithThatValue()
+        {
+            // given
+            var directives = new[]
+            {
+                DefinitionDirective.Atomic,
+                DefinitionDirective.IgnoreCase
+            };
+            var expr = new Expression(new LiteralSubExpression("value"));
+            var def = new Definition("def1", directives, expr, true);
+            // when
+            var result = def.Clone(newName: "def2");
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual("def2", result.Name);
+            Assert.IsNotEmpty(result.Directives);
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.Atomic));
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.IgnoreCase));
+            Assert.IsNotNull(result.Expr);
+            Assert.AreSame(expr, result.Expr);
+            Assert.IsTrue(result.IsImported);
+        }
+
+        [Test]
+        public void CloneWithNewDirectiveYieldsCopyWithThatValue()
+        {
+            // given
+            var directives = new[]
+            {
+                DefinitionDirective.Atomic,
+                DefinitionDirective.IgnoreCase
+            };
+            var expr = new Expression(new LiteralSubExpression("value"));
+            var def = new Definition("def1", directives, expr, true);
+            // when
+            var result = def.Clone(
+                newDirectives: new []{DefinitionDirective.MindWhitespace});
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual("def1", result.Name);
+            Assert.IsNotEmpty(result.Directives);
+            Assert.IsFalse(
+                result.Directives.Contains(DefinitionDirective.Atomic));
+            Assert.IsFalse(
+                result.Directives.Contains(DefinitionDirective.IgnoreCase));
+            Assert.IsTrue(
+                result.Directives.Contains(
+                    DefinitionDirective.MindWhitespace));
+            Assert.IsNotNull(result.Expr);
+            Assert.AreSame(expr, result.Expr);
+            Assert.IsTrue(result.IsImported);
+        }
+
+        [Test]
+        public void CloneWithNewExprYieldsCopyWithThatValue()
+        {
+            // given
+            var directives = new[]
+            {
+                DefinitionDirective.Atomic,
+                DefinitionDirective.IgnoreCase
+            };
+            var expr1 = new Expression(new LiteralSubExpression("value"));
+            var expr2 = new Expression(new CharClassSubExpression(
+                CharClass.FromUndelimitedCharClassText("\\l")));
+            var def = new Definition("def1", directives, expr1, true);
+            // when
+            var result = def.Clone(newExpr: expr2);
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual("def1", result.Name);
+            Assert.IsNotEmpty(result.Directives);
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.Atomic));
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.IgnoreCase));
+            Assert.IsNotNull(result.Expr);
+            Assert.AreNotSame(expr1, result.Expr);
+            Assert.AreSame(expr2, result.Expr);
+            Assert.IsTrue(result.IsImported);
+        }
+
+        [Test]
+        public void CloneWithNewIsImportedYieldsCopyWithThatValue()
+        {
+            // given
+            var directives = new[]
+            {
+                DefinitionDirective.Atomic,
+                DefinitionDirective.IgnoreCase
+            };
+            var expr = new Expression(new LiteralSubExpression("value"));
+            var def = new Definition("def1", directives, expr, true);
+            // when
+            var result = def.Clone(newIsImported: false);
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual("def1", result.Name);
+            Assert.IsNotEmpty(result.Directives);
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.Atomic));
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.IgnoreCase));
+            Assert.IsNotNull(result.Expr);
+            Assert.AreSame(expr, result.Expr);
+            Assert.IsFalse(result.IsImported);
+        }
+
+        [Test]
+        public void CloneWithNewIsImportedYieldsCopyWithThatValue2()
+        {
+            // given
+            var directives = new[]
+            {
+                DefinitionDirective.Atomic,
+                DefinitionDirective.IgnoreCase
+            };
+            var expr = new Expression(new LiteralSubExpression("value"));
+            var def = new Definition("def1", directives, expr, false);
+            // when
+            var result = def.Clone(newIsImported: true);
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual("def1", result.Name);
+            Assert.IsNotEmpty(result.Directives);
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.Atomic));
+            Assert.IsTrue(
+                result.Directives.Contains(DefinitionDirective.IgnoreCase));
+            Assert.IsNotNull(result.Expr);
+            Assert.AreSame(expr, result.Expr);
+            Assert.IsTrue(result.IsImported);
+        }
+
+        [Test]
+        public void ToStringIncludesName()
+        {
+            // given
+            var def = new Definition("def1");
+            // when
+            var result = def.ToString();
+            // then
+            Assert.AreEqual("Definition def1", result);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Giza.Test/ImportTransformTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/ImportTransformTest.cs
@@ -419,5 +419,35 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.AreEqual("/base/path2/file2.giza",
                 result.Definitions[0].Source);
         }
+
+        [Test]
+        public void TransformRemovesImportStatments()
+        {
+            // given
+            const string file1 = "";
+            var mfs = new MockFileSource(s => file1);
+
+            // import 'file1.txt';
+            var g = new Grammar(
+                new List<Definition>(),
+                new List<ImportStatement>
+                {
+                    new ImportStatement
+                    {
+                        Filename = "file1.txt",
+                    }
+                },
+                "src");
+            var importer = new ImportTransform(fileSource: mfs);
+            var errors = new List<Error>();
+            // when
+            var result = importer.Transform(g, errors, mfs);
+            // then
+            Assert.AreEqual(0, errors.Count);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Definitions.Count);
+            Assert.AreEqual(0, result.ImportStatements.Count);
+            Assert.AreEqual("src", result.Source);
+        }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/ImportTransformTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/ImportTransformTest.cs
@@ -15,17 +15,15 @@ namespace MetaphysicsIndustries.Giza.Test
             var mfs = new MockFileSource((s) => file1);
 
             // import 'file1.txt';
-            var g = new Grammar
-            {
-                Definitions = new List<Definition>(),
-                ImportStatements = new List<ImportStatement>
+            var g = new Grammar(
+                new List<Definition>(),
+                new List<ImportStatement>
                 {
                     new ImportStatement
                     {
                         Filename = "file1.txt",
                     }
-                }
-            };
+                });
             var importer = new ImportTransform(fileSource: mfs);
             var errors = new List<Error>();
             // when
@@ -49,15 +47,14 @@ namespace MetaphysicsIndustries.Giza.Test
             var file1 = @"def1 = 'a'; def2 = 'b';";
             var mfs = new MockFileSource((s) => file1);
             // from 'file1.txt' import def1;
-            var g = new Grammar
-            {
-                Definitions = new List<Definition>(),
-                ImportStatements = new List<ImportStatement>
+            var g = new Grammar(
+                new List<Definition>(),
+                new List<ImportStatement>
                 {
                     new ImportStatement
                     {
                         Filename = "file1.txt",
-                        ImportRefs = new []
+                        ImportRefs = new[]
                         {
                             new ImportRef
                             {
@@ -66,8 +63,7 @@ namespace MetaphysicsIndustries.Giza.Test
                             }
                         }
                     }
-                }
-            };
+                });
             var importer = new ImportTransform(fileSource: mfs);
             var errors = new List<Error>();
             // when
@@ -88,10 +84,9 @@ namespace MetaphysicsIndustries.Giza.Test
             var mfs = new MockFileSource((s) => file1);
 
             // from 'file1.txt' import def1, def3;
-            var g = new Grammar
-            {
-                Definitions = new List<Definition>(),
-                ImportStatements = new List<ImportStatement>
+            var g = new Grammar(
+                new List<Definition>(),
+                new List<ImportStatement>
                 {
                     new ImportStatement
                     {
@@ -110,8 +105,7 @@ namespace MetaphysicsIndustries.Giza.Test
                             },
                         }
                     }
-                }
-            };
+                });
             var importer = new ImportTransform(mfs);
             var errors = new List<Error>();
             // when
@@ -139,17 +133,15 @@ namespace MetaphysicsIndustries.Giza.Test
                 return "def1 = 'a';";
             });
             // import 'file1.txt';
-            var g = new Grammar
-            {
-                Definitions = new List<Definition>(),
-                ImportStatements = new List<ImportStatement>
+            var g = new Grammar(
+                new List<Definition>(),
+                new List<ImportStatement>
                 {
                     new ImportStatement
                     {
                         Filename = "file1.txt",
                     }
-                }
-            };
+                });
 
             var importer = new ImportTransform(mfs);
             var errors1 = new List<Error>();
@@ -182,14 +174,13 @@ namespace MetaphysicsIndustries.Giza.Test
             // import 'file2.txt';
             // import 'file3.txt';
             // def4 = 'd';
-            var g = new Grammar
-            {
-                Definitions = new List<Definition>
+            var g = new Grammar(
+                new List<Definition>
                 {
                     new Definition("def4",
                         expr: new Expression(new LiteralSubExpression("d"))),
                 },
-                ImportStatements = new List<ImportStatement>
+                new List<ImportStatement>
                 {
                     new ImportStatement
                     {
@@ -201,8 +192,7 @@ namespace MetaphysicsIndustries.Giza.Test
                         Filename = "file3.txt",
                         ImportAll = true
                     },
-                }
-            };
+                });
 
             var mfs = new MockFileSource(s =>
             {
@@ -254,10 +244,9 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // import 'file1.txt';
             // import 'file2.txt';
-            var g = new Grammar
-            {
-                Definitions = new List<Definition>(),
-                ImportStatements = new List<ImportStatement>
+            var g = new Grammar(
+                new List<Definition>(),
+                new List<ImportStatement>
                 {
                     new ImportStatement
                     {
@@ -269,8 +258,7 @@ namespace MetaphysicsIndustries.Giza.Test
                         Filename = "file2.txt",
                         ImportAll = true
                     },
-                }
-            };
+                });
             var importer = new ImportTransform(mfs);
             var errors = new List<Error>();
             // when
@@ -301,10 +289,9 @@ namespace MetaphysicsIndustries.Giza.Test
             });
             // from 'file1.txt' import def1;
             // from 'file2.txt' import def1 as def2;
-            var g = new Grammar
-            {
-                Definitions = new List<Definition>(),
-                ImportStatements = new List<ImportStatement>
+            var g = new Grammar(
+                new List<Definition>(),
+                new List<ImportStatement>
                 {
                     new ImportStatement
                     {
@@ -330,8 +317,7 @@ namespace MetaphysicsIndustries.Giza.Test
                             }
                         }
                     },
-                }
-            };
+                });
             var importer = new ImportTransform(mfs);
             var errors = new List<Error>();
             // when

--- a/MetaphysicsIndustries.Giza.Test/ImportTransformTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/ImportTransformTest.cs
@@ -346,5 +346,37 @@ namespace MetaphysicsIndustries.Giza.Test
             var literal2 = (LiteralSubExpression) def2.Expr.Items[0];
             Assert.AreEqual("b", literal2.Value);
         }
+
+        [Test]
+        public void ImportingSetsTheDefinitionSource()
+        {
+            // given
+            var file1 = @"def1 = 'a';";
+            var mfs = new MockFileSource((s) => file1);
+
+            // import 'file1.txt';
+            var g = new Grammar(
+                new List<Definition>(),
+                new List<ImportStatement>
+                {
+                    new ImportStatement
+                    {
+                        Filename = "file1.txt",
+                    }
+                },
+                "src1");
+            var importer = new ImportTransform(fileSource: mfs);
+            var errors = new List<Error>();
+            // when
+            var result = importer.Transform(g, errors, mfs);
+            // then
+            Assert.AreEqual(0, errors.Count);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("src1", result.Source);
+            Assert.AreEqual(1, result.Definitions.Count);
+            Assert.AreEqual("def1", result.Definitions[0].Name);
+            Assert.IsTrue(result.Definitions[0].IsImported);
+            Assert.AreEqual("file1.txt", result.Definitions[0].Source);
+        }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/MetaphysicsIndustries.Giza.Test.csproj
+++ b/MetaphysicsIndustries.Giza.Test/MetaphysicsIndustries.Giza.Test.csproj
@@ -35,6 +35,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CSharpPathTest.cs" />
     <Compile Include="DefinitionTest.cs" />
     <Compile Include="ImportTest.cs" />
     <Compile Include="ImportTransformTest.cs" />

--- a/MetaphysicsIndustries.Giza.Test/MetaphysicsIndustries.Giza.Test.csproj
+++ b/MetaphysicsIndustries.Giza.Test/MetaphysicsIndustries.Giza.Test.csproj
@@ -42,6 +42,7 @@
     <Compile Include="MockFileSource.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DefinitionCheckerTest.cs" />
+    <Compile Include="SupergrammarSpannerTest.cs" />
     <Compile Include="TokenizerTest.cs" />
     <Compile Include="GrammarCompilerTest.cs" />
     <Compile Include="ExpressionCheckerTest.cs" />

--- a/MetaphysicsIndustries.Giza.Test/MetaphysicsIndustries.Giza.Test.csproj
+++ b/MetaphysicsIndustries.Giza.Test/MetaphysicsIndustries.Giza.Test.csproj
@@ -35,6 +35,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DefinitionTest.cs" />
     <Compile Include="ImportTest.cs" />
     <Compile Include="ImportTransformTest.cs" />
     <Compile Include="MockFileSource.cs" />

--- a/MetaphysicsIndustries.Giza.Test/MockFileSource.cs
+++ b/MetaphysicsIndustries.Giza.Test/MockFileSource.cs
@@ -5,17 +5,17 @@ namespace MetaphysicsIndustries.Giza.Test
 {
     public class MockFileSource : IFileSource
     {
-        public MockFileSource()
-            : this((s)=>"")
+        public MockFileSource(Func<string, string> getFileContents=null,
+            string pwd=null)
         {
-        }
+            if (getFileContents == null) getFileContents = s => "";
 
-        public MockFileSource(Func<string, string> getFileContents)
-        {
             GetFileContentsP = getFileContents;
+            Pwd = pwd;
         }
 
         public Func<string, string> GetFileContentsP { get; set; }
+        public string Pwd;
 
         public string GetFileContents(string filename)
         {
@@ -23,6 +23,17 @@ namespace MetaphysicsIndustries.Giza.Test
                 throw new FileNotFoundException(
                     "Could not find file \"{0}\"", filename);
             return GetFileContentsP(filename);
+        }
+
+        public string CombinePath(string fromFile, string toFile)
+        {
+            if (Pwd == null) return toFile;
+
+            var a1 = fromFile;
+            var a2 = Path.GetDirectoryName(a1);
+            var a3 = Path.Combine(a2, toFile);
+            var a4 = Path.GetFullPath(a3);
+            return a4;
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/SupergrammarSpannerTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/SupergrammarSpannerTest.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Giza.Test
+{
+    [TestFixture]
+    public class SupergrammarSpannerTest
+    {
+        [Test]
+        public void TestGetGrammarSetsSources()
+        {
+            const string input = "def1 = 'a';";
+            const string source = "grammar1.giza";
+            var ss = new SupergrammarSpanner();
+            var errors = new List<Error>();
+            // when
+            var result = ss.GetGrammar(input, errors, source);
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual(source, result.Source);
+            Assert.AreEqual(1, result.Definitions.Count);
+            Assert.AreEqual("def1", result.Definitions[0].Name);
+            Assert.AreEqual(source, result.Definitions[0].Source);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Giza.Test/TokenizeTransformTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/TokenizeTransformTest.cs
@@ -705,6 +705,43 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsNotNull(implicitDef);
             Assert.IsTrue(implicitDef.IsImported); // should it be, though?
         }
+
+        [Test]
+        public void TestSourceStaysTheSame()
+        {
+            // given
+            var g = new Grammar(
+                //def = 'value';
+                new[]
+                {
+                    new Definition(
+                        name: "def",
+                        expr: new Expression(
+                            new LiteralSubExpression(value: "value")),
+                        source: "src1")  // here's the important bit
+                },
+                null,
+                "src1");
+            var tt = new TokenizeTransform();
+            // when
+            var result = tt.Tokenize(g);
+            // then
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Definitions.Count);
+            Assert.AreEqual("src1", result.Source);
+
+            var explicitDef = result.FindDefinitionByName("def");
+            Assert.IsNotNull(explicitDef);
+            Assert.AreEqual("src1", explicitDef.Source); //
+            Assert.AreNotSame(explicitDef,g.Definitions[0]);
+
+            var implicitDef =
+                result.FindDefinitionByName("$implicit literal value");
+            Assert.IsNotNull(implicitDef);
+
+            Assert.AreEqual("src1", implicitDef.Source);
+            // should it be, though?
+        }
     }
 }
 

--- a/MetaphysicsIndustries.Giza.Test/TokenizeTransformTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/TokenizeTransformTest.cs
@@ -39,7 +39,7 @@ namespace MetaphysicsIndustries.Giza.Test
                     expr: new Expression(
                         new LiteralSubExpression(value: "value")))
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -100,7 +100,7 @@ namespace MetaphysicsIndustries.Giza.Test
                         new CharClassSubExpression(
                             CharClass.FromUndelimitedCharClassText("\\d"))))
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -164,7 +164,7 @@ namespace MetaphysicsIndustries.Giza.Test
                     }
                 )
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -231,7 +231,7 @@ namespace MetaphysicsIndustries.Giza.Test
                     }
                 )
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -295,7 +295,7 @@ namespace MetaphysicsIndustries.Giza.Test
                     }
                 )
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -337,7 +337,7 @@ namespace MetaphysicsIndustries.Giza.Test
                     expr: new Expression(
                         new LiteralSubExpression("value")))
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -387,7 +387,7 @@ namespace MetaphysicsIndustries.Giza.Test
                     expr: new Expression(
                         new LiteralSubExpression("value")))
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -435,7 +435,7 @@ namespace MetaphysicsIndustries.Giza.Test
                         new LiteralSubExpression("value"))
                 )
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -492,7 +492,7 @@ namespace MetaphysicsIndustries.Giza.Test
                     expr: new Expression(
                         new LiteralSubExpression("token")))
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -540,7 +540,7 @@ namespace MetaphysicsIndustries.Giza.Test
                     expr: new Expression(
                         new LiteralSubExpression("value")))
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -591,7 +591,7 @@ namespace MetaphysicsIndustries.Giza.Test
                     expr: new Expression(
                         new LiteralSubExpression("value")))
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -642,7 +642,7 @@ namespace MetaphysicsIndustries.Giza.Test
                     expr: new Expression(
                         new LiteralSubExpression("value")))
             };
-            var g = new Grammar() {Definitions = dis.ToList()};
+            var g = new Grammar(dis);
             var tt = new TokenizeTransform();
 
 
@@ -680,18 +680,16 @@ namespace MetaphysicsIndustries.Giza.Test
         public void TestImportedStaysImported()
         {
             // given
-            var g = new Grammar
-            {
+            var g = new Grammar(
                 //def = 'value';
-                Definitions = new List<Definition>
+                new[]
                 {
                     new Definition(
                         name: "def",
                         expr: new Expression(
                             new LiteralSubExpression(value: "value")),
                         isImported: true)  // here's the important bit
-                }
-            };
+                });
             var tt = new TokenizeTransform();
             // when
             var result = tt.Tokenize(g);

--- a/MetaphysicsIndustries.Giza.Test/TokenizeTransformTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/TokenizeTransformTest.cs
@@ -688,10 +688,8 @@ namespace MetaphysicsIndustries.Giza.Test
                     new Definition(
                         name: "def",
                         expr: new Expression(
-                            new LiteralSubExpression(value: "value")))
-                    {
-                        IsImported = true  // here's the important bit
-                    }
+                            new LiteralSubExpression(value: "value")),
+                        isImported: true)  // here's the important bit
                 }
             };
             var tt = new TokenizeTransform();

--- a/SupergrammarSpanner.cs
+++ b/SupergrammarSpanner.cs
@@ -36,7 +36,8 @@ namespace MetaphysicsIndustries.Giza
 {
     public class SupergrammarSpanner
     {
-        public Grammar GetGrammar(string input, List<Error> errors)
+        public Grammar GetGrammar(string input, List<Error> errors,
+            string source=null)
         {
             Supergrammar supergrammar = new Supergrammar();
             Spanner spanner = new Spanner(supergrammar.def_grammar);
@@ -125,10 +126,11 @@ namespace MetaphysicsIndustries.Giza
                 def.Directives.UnionWith(directives);
             }
 
-            return new Grammar()
+            return new Grammar
             {
                 Definitions = defs,
                 ImportStatements = importStmts,
+                Source = source
             };
         }
 

--- a/SupergrammarSpanner.cs
+++ b/SupergrammarSpanner.cs
@@ -126,12 +126,7 @@ namespace MetaphysicsIndustries.Giza
                 def.Directives.UnionWith(directives);
             }
 
-            return new Grammar
-            {
-                Definitions = defs,
-                ImportStatements = importStmts,
-                Source = source
-            };
+            return new Grammar(defs, importStmts, source);
         }
 
         ImportStatement GetImportStatementFromSpan(

--- a/SupergrammarSpanner.cs
+++ b/SupergrammarSpanner.cs
@@ -39,6 +39,9 @@ namespace MetaphysicsIndustries.Giza
         public Grammar GetGrammar(string input, List<Error> errors,
             string source=null)
         {
+            if (string.IsNullOrWhiteSpace(input))
+                return new Grammar(source: source);
+
             Supergrammar supergrammar = new Supergrammar();
             Spanner spanner = new Spanner(supergrammar.def_grammar);
             Span[] s2 = spanner.Process(input.ToCharacterSource(), errors);

--- a/SupergrammarSpanner.cs
+++ b/SupergrammarSpanner.cs
@@ -64,12 +64,9 @@ namespace MetaphysicsIndustries.Giza
                 return null;
             }
 
-            var g = BuildPreGrammar(supergrammar, s2[0], errors);
-            return g;
-        }
+            var grammar = supergrammar;
+            var span = s2[0];
 
-        public Grammar BuildPreGrammar(Supergrammar grammar, Span span, List<Error> errors)
-        {
             if (!(span.Node is DefRefNode) ||
                 (span.Node as DefRefNode).DefRef != grammar.def_grammar)
             {

--- a/SupergrammarSpanner.cs
+++ b/SupergrammarSpanner.cs
@@ -143,7 +143,6 @@ namespace MetaphysicsIndustries.Giza
                 throw new ArgumentException("The span must describe an import-stmt.");
             var stmtType = importSpan.Subspans[0];
             Span source;
-            // TODO: relative imports should be relative to the importing file.
             List<ImportRef> defNamesToImport = null;
             bool importAll = false;
             if (stmtType.Node == importingGrammar.node_import_002D_stmt_0_import)

--- a/SupergrammarSpanner.cs
+++ b/SupergrammarSpanner.cs
@@ -103,7 +103,7 @@ namespace MetaphysicsIndustries.Giza
                     // TODO: add an error? throw an exception?
                     continue;
 
-                Definition def = new Definition();
+                Definition def = new Definition(source: source);
                 defs.Add(def);
 
                 List<DefinitionDirective> directives = new List<DefinitionDirective>();

--- a/TokenizeTransform.cs
+++ b/TokenizeTransform.cs
@@ -134,11 +134,7 @@ namespace MetaphysicsIndustries.Giza
             var outdefs = new List<Definition>();
             outdefs.AddRange(nonTokenizedDefs);
             outdefs.AddRange(tokenizedDefs);
-            return new Grammar
-            {
-                Definitions = outdefs,
-                Source = g.Source,
-            };
+            return g.Clone(outdefs);
         }
 
         string GetImplicitDefinitionName(LiteralSubExpression literal, bool ignoreCase)

--- a/TokenizeTransform.cs
+++ b/TokenizeTransform.cs
@@ -134,7 +134,11 @@ namespace MetaphysicsIndustries.Giza
             var outdefs = new List<Definition>();
             outdefs.AddRange(nonTokenizedDefs);
             outdefs.AddRange(tokenizedDefs);
-            return new Grammar() {Definitions = outdefs};
+            return new Grammar
+            {
+                Definitions = outdefs,
+                Source = g.Source,
+            };
         }
 
         string GetImplicitDefinitionName(LiteralSubExpression literal, bool ignoreCase)

--- a/TokenizeTransform.cs
+++ b/TokenizeTransform.cs
@@ -76,21 +76,14 @@ namespace MetaphysicsIndustries.Giza
                         var defname = GetImplicitDefinitionName(literal, ignoreCase);
                         if (!implicitTokenDefs.ContainsKey(defname))
                         {
-                            var def2 = new Definition
-                            {
-                                Name = defname,
-                                IsImported = def.IsImported,
-                            };
-                            def2.Expr = new Expression(
-                                new LiteralSubExpression
-                                {
-                                    Value = literal.Value
-                                });
-                            def2.Directives.Add(DefinitionDirective.Token);
+                            var def2 = def.Clone(
+                                defname,
+                                new[] {DefinitionDirective.Token},
+                                new Expression(
+                                    new LiteralSubExpression(literal.Value)));
                             if (ignoreCase)
-                            {
-                                def2.Directives.Add(DefinitionDirective.IgnoreCase);
-                            }
+                                def2.Directives.Add(
+                                    DefinitionDirective.IgnoreCase);
 
                             implicitTokenDefs[defname] = def2;
                         }
@@ -102,21 +95,15 @@ namespace MetaphysicsIndustries.Giza
                         var defname = GetImplicitDefinitionName(cc, ignoreCase);
                         if (!implicitTokenDefs.ContainsKey(defname))
                         {
-                            var def2 = new Definition
-                            {
-                                Name = defname,
-                                IsImported = def.IsImported,
-                            };
-                            def2.Expr = new Expression(
-                                new CharClassSubExpression()
-                                {
-                                    CharClass = cc.CharClass
-                                });
-                            def2.Directives.Add(DefinitionDirective.Token);
+                            var def2 = def.Clone(
+                                defname,
+                                new [] {DefinitionDirective.Token},
+                                new Expression(
+                                    new CharClassSubExpression(
+                                        cc.CharClass)));
                             if (ignoreCase)
-                            {
-                                def2.Directives.Add(DefinitionDirective.IgnoreCase);
-                            }
+                                def2.Directives.Add(
+                                    DefinitionDirective.IgnoreCase);
 
                             implicitTokenDefs[defname] = def2;
                         }
@@ -171,12 +158,9 @@ namespace MetaphysicsIndustries.Giza
             Dictionary<LiteralSubExpression, Definition> defsByLiteral,
             Dictionary<CharClassSubExpression, Definition> defsByCharClass)
         {
-            return new Definition(def.Name, def.Directives,
-                ReplaceInExpression(def.Expr, defsByLiteral,
-                    defsByCharClass))
-            {
-                IsImported = def.IsImported,
-            };
+            return def.Clone(
+                newExpr: ReplaceInExpression(def.Expr, defsByLiteral,
+                    defsByCharClass));
         }
 
         public Expression ReplaceInExpression(Expression expr,

--- a/giza/CheckCommand.cs
+++ b/giza/CheckCommand.cs
@@ -63,14 +63,14 @@ namespace giza
                 grammar = File.ReadAllText(grammarFilename);
             }
 
-            Check(grammar, tokenized);
+            Check(grammar, tokenized, grammarFilename);
         }
 
-        public static void Check(string grammar, bool tokenized)
+        public static void Check(string grammar, bool tokenized, string source)
         {
             var sgs = new SupergrammarSpanner();
             var errors = new List<Error>();
-            var g = sgs.GetGrammar(grammar, errors);
+            var g = sgs.GetGrammar(grammar, errors, source);
 
             if (!errors.ContainsNonWarnings())
             {

--- a/giza/CheckReplCommand.cs
+++ b/giza/CheckReplCommand.cs
@@ -86,7 +86,8 @@ namespace giza
             {
                 var g = new Grammar()
                 {
-                    Definitions = defs
+                    Definitions = defs,
+                    Source = "<repl>"
                 };
                 var g2 = g;
                 if (tokenized)

--- a/giza/CheckReplCommand.cs
+++ b/giza/CheckReplCommand.cs
@@ -84,11 +84,7 @@ namespace giza
 
             if (!errors.ContainsNonWarnings())
             {
-                var g = new Grammar()
-                {
-                    Definitions = defs,
-                    Source = "<repl>"
-                };
+                var g = new Grammar(defs, source: "<repl>");
                 var g2 = g;
                 if (tokenized)
                 {

--- a/giza/LoadReplCommand.cs
+++ b/giza/LoadReplCommand.cs
@@ -50,7 +50,7 @@ namespace giza
 
             var errors = new List<Error>();
             var spanner = new SupergrammarSpanner();
-            var g = spanner.GetGrammar(contents, errors);
+            var g = spanner.GetGrammar(contents, errors, filename);
             var defs = g.Definitions;
             if (errors.ContainsNonWarnings())
             {

--- a/giza/ParseCommand.cs
+++ b/giza/ParseCommand.cs
@@ -93,14 +93,15 @@ namespace giza
                 input = File.ReadAllText(inputFilename);
             }
 
-            Parse(grammar, input, startDef, printingOptions);
+            Parse(grammar, input, startDef, printingOptions, grammarFilename);
         }
 
-        public static void Parse(string grammar, string input, string startDef, SpanPrintingOptions printingOptions)
+        public static void Parse(string grammar, string input, string startDef,
+            SpanPrintingOptions printingOptions, string source)
         {
             var spanner = new SupergrammarSpanner();
             var grammarErrors = new List<Error>();
-            var g = spanner.GetGrammar(grammar, grammarErrors);
+            var g = spanner.GetGrammar(grammar, grammarErrors, source);
 
             if (!grammarErrors.ContainsNonWarnings())
             {

--- a/giza/ParseReplCommand.cs
+++ b/giza/ParseReplCommand.cs
@@ -108,11 +108,7 @@ namespace giza
             if (!errors.ContainsNonWarnings())
             {
                 var tt = new TokenizeTransform();
-                var g = new Grammar()
-                {
-                    Definitions = Env.Values.ToList(),
-                    Source = "<repl>"
-                };
+                var g = new Grammar(Env.Values, source: "<repl>");
                 var g2 = tt.Tokenize(g);
                 var gc = new GrammarCompiler();
                 grammar = gc.Compile(g2);

--- a/giza/ParseReplCommand.cs
+++ b/giza/ParseReplCommand.cs
@@ -108,7 +108,11 @@ namespace giza
             if (!errors.ContainsNonWarnings())
             {
                 var tt = new TokenizeTransform();
-                var g = new Grammar() {Definitions = Env.Values.ToList()};
+                var g = new Grammar()
+                {
+                    Definitions = Env.Values.ToList(),
+                    Source = "<repl>"
+                };
                 var g2 = tt.Tokenize(g);
                 var gc = new GrammarCompiler();
                 grammar = gc.Compile(g2);

--- a/giza/Program.cs
+++ b/giza/Program.cs
@@ -171,7 +171,8 @@ namespace giza
                         while (true)
                         {
                             var errors = new List<Error>();
-                            var g = spanner.GetGrammar(buffer.ToString(), errors);
+                            var g = spanner.GetGrammar(buffer.ToString(),
+                                errors, "<repl>");
                             var defs = g.Definitions;
                             if (!errors.ContainsNonWarnings())
                             {

--- a/giza/RenderCommand.cs
+++ b/giza/RenderCommand.cs
@@ -106,17 +106,17 @@ namespace giza
             }
 
             Render(tokenized, ns, singleton, grammar, className, baseClassName,
-                usings, skipImported);
+                usings, skipImported, grammarFilename);
         }
 
         public static void Render(bool tokenized, string ns, bool isSingleton,
             string grammar, string className, string baseClassName,
-            string[] usings, bool skipImported)
+            string[] usings, bool skipImported, string source)
         {
 
             var sgs = new SupergrammarSpanner();
             var errors = new List<Error>();
-            var g0 = sgs.GetGrammar(grammar, errors);
+            var g0 = sgs.GetGrammar(grammar, errors, source);
 
             if (errors.Count > 0)
             {

--- a/giza/RenderReplCommand.cs
+++ b/giza/RenderReplCommand.cs
@@ -127,7 +127,8 @@ namespace giza
 
             var g = new Grammar
             {
-                Definitions = alldefs.ToList()
+                Definitions = alldefs.ToList(),
+                Source = "<repl>"
             };
             var g2 = g;
             if (tokenized)

--- a/giza/RenderReplCommand.cs
+++ b/giza/RenderReplCommand.cs
@@ -125,11 +125,7 @@ namespace giza
 
             if (someAreMissing) return;
 
-            var g = new Grammar
-            {
-                Definitions = alldefs.ToList(),
-                Source = "<repl>"
-            };
+            var g = new Grammar(alldefs, source: "<repl>");
             var g2 = g;
             if (tokenized)
             {

--- a/giza/SpanCommand.cs
+++ b/giza/SpanCommand.cs
@@ -90,14 +90,15 @@ namespace giza
                 input = File.ReadAllText(inputFilename);
             }
 
-            Span(grammar, input, startDef, printingOptions);
+            Span(grammar, input, startDef, printingOptions, grammarFilename);
         }
 
-        public static void Span(string grammar, string input, string startDef, SpanPrintingOptions printingOptions)
+        public static void Span(string grammar, string input, string startDef,
+            SpanPrintingOptions printingOptions, string source)
         {
             var spanner = new SupergrammarSpanner();
             var errors = new List<Error>();
-            var g = spanner.GetGrammar(grammar, errors);
+            var g = spanner.GetGrammar(grammar, errors, source);
 
             if (errors != null && errors.Count > 0)
             {


### PR DESCRIPTION
This PR fixes imports so that relative paths like `../path/to/grammar.giza' work correctly. Previously, paths were interpreted relative to the current directory. With the new changes, paths are relative to the importing file.