### PR TITLE
Bug skippable items

### DIFF
--- a/GrammarCompiler.cs
+++ b/GrammarCompiler.cs
@@ -73,7 +73,7 @@ namespace MetaphysicsIndustries.Giza
             return new NGrammar(defs2);
         }
 
-        NodeBundle GetNodesFromExpression(Expression expr, 
+        public NodeBundle GetNodesFromExpression(Expression expr,
             Dictionary<string, NDefinition> defsByName)
         {
             NodeBundle first = null;
@@ -265,7 +265,7 @@ namespace MetaphysicsIndustries.Giza
                 };
         }
 
-        NodeBundle GetNodesFromOrExpression(OrExpression orexpr,
+        public NodeBundle GetNodesFromOrExpression(OrExpression orexpr,
             Dictionary<string, NDefinition> defsByName)
         {
             var bundles = new List<NodeBundle>();

--- a/GrammarCompiler.cs
+++ b/GrammarCompiler.cs
@@ -127,15 +127,15 @@ namespace MetaphysicsIndustries.Giza
             }
 
             // inter-bundle skips
+            var prevs = new HashSet<Node>(bundles[0].EndNodes);
             for (i = 2; i < bundles.Count; i++)
             {
                 if (bundles[i - 1].IsSkippable)
-                {
-                    foreach (Node prev in bundles[i-2].EndNodes)
-                    {
+                    foreach (var prev in prevs)
                         prev.NextNodes.UnionWith(bundles[i].StartNodes);
-                    }
-                }
+                else
+                    prevs.Clear();
+                prevs.AddRange(bundles[i - 1].EndNodes);
             }
 
             // skip from start to inner bundle

--- a/MetaphysicsIndustries.Giza.Test/GrammarCompilerT/GetNodesFromExpressionTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/GrammarCompilerT/GetNodesFromExpressionTest.cs
@@ -1,0 +1,283 @@
+
+// MetaphysicsIndustries.Giza - A Parsing System
+// Copyright (C) 2008-2021 Metaphysics Industries, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+// USA
+
+using System.Linq;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
+{
+    [TestFixture]
+    public class GetNodesFromExpressionTest
+    {
+        [Test]
+        public void SingleItemYieldsSimpleNode()
+        {
+            // given
+            var expr = new Expression(
+                new LiteralSubExpression("a"));
+            var gc = new GrammarCompiler();
+            // when
+            var result = gc.GetNodesFromExpression(expr, null);
+            // then
+            Assert.IsFalse(result.IsSkippable);
+            Assert.AreEqual(1, result.Nodes.Count);
+            Assert.AreEqual(1, result.StartNodes.Count);
+            Assert.AreEqual(1, result.EndNodes.Count);
+            var node = result.Nodes[0];
+            Assert.Contains(node, result.StartNodes.ToList());
+            Assert.Contains(node, result.EndNodes.ToList());
+            Assert.IsEmpty(node.NextNodes);
+            Assert.IsFalse(result.IsSkippable);
+        }
+
+        [Test]
+        public void MultipleItemsYieldMultipleNodes()
+        {
+            // given
+            var expr = new Expression(
+                new LiteralSubExpression("a"),
+                new LiteralSubExpression("b"));
+            var gc = new GrammarCompiler();
+            // when
+            var result = gc.GetNodesFromExpression(expr, null);
+            // then
+            Assert.IsFalse(result.IsSkippable);
+            Assert.AreEqual(2, result.Nodes.Count);
+            Assert.AreEqual(1, result.StartNodes.Count);
+            Assert.AreEqual(1, result.EndNodes.Count);
+            var node0 = result.Nodes[0];
+            var node1 = result.Nodes[1];
+            Assert.Contains(node0, result.StartNodes.ToList());
+            Assert.Contains(node1, result.EndNodes.ToList());
+            Assert.AreEqual(1, node0.NextNodes.Count);
+            Assert.Contains(node1, node0.NextNodes.ToList());
+            Assert.IsEmpty(node1.NextNodes);
+            Assert.IsFalse(result.IsSkippable);
+        }
+
+        [Test]
+        public void SkippableFirstItemYieldsSecondNodeAlsoStartNode()
+        {
+            // given
+            var expr = new Expression(
+                new LiteralSubExpression("a", isSkippable: true),
+                new LiteralSubExpression("b"));
+            var gc = new GrammarCompiler();
+            // when
+            var result = gc.GetNodesFromExpression(expr, null);
+            // then
+            Assert.IsFalse(result.IsSkippable);
+            Assert.AreEqual(2,result.Nodes.Count);
+            Assert.AreEqual(2,result.StartNodes.Count);
+            Assert.AreEqual(1,result.EndNodes.Count);
+            var node0 = result.Nodes[0];
+            Assert.Contains(node0, result.StartNodes.ToList());
+            Assert.IsFalse(result.EndNodes.Contains(node0));
+            var node1 = result.Nodes[1];
+            Assert.Contains(node1, result.StartNodes.ToList());
+            Assert.Contains(node1, result.EndNodes.ToList());
+            Assert.IsFalse(result.IsSkippable);
+        }
+
+        [Test]
+        public void SkippableSecondItemYieldsFirstNodeAlsoEndNode()
+        {
+            // given
+            var expr = new Expression(
+                new LiteralSubExpression("a"),
+                new LiteralSubExpression("b", isSkippable: true));
+            var gc = new GrammarCompiler();
+            // when
+            var result = gc.GetNodesFromExpression(expr, null);
+            // then
+            Assert.IsFalse(result.IsSkippable);
+            Assert.AreEqual(2,result.Nodes.Count);
+            Assert.AreEqual(1,result.StartNodes.Count);
+            Assert.AreEqual(2,result.EndNodes.Count);
+            var node0 = result.Nodes[0];
+            Assert.Contains(node0, result.StartNodes.ToList());
+            Assert.Contains(node0, result.EndNodes.ToList());
+            var node1 = result.Nodes[1];
+            Assert.IsFalse(result.StartNodes.Contains(node1));
+            Assert.Contains(node1, result.EndNodes.ToList());
+            Assert.IsFalse(result.IsSkippable);
+        }
+
+        [Test]
+        public void NonSubsequentSkippableItemsYieldsSimpleGraph()
+        {
+            // given
+            var expr = new Expression(
+                new LiteralSubExpression("a"),
+                new LiteralSubExpression("b", isSkippable: true),
+                new LiteralSubExpression("c"),
+                new LiteralSubExpression("d", isSkippable: true),
+                new LiteralSubExpression("e"));
+            var gc = new GrammarCompiler();
+            // when
+            var result = gc.GetNodesFromExpression(expr, null);
+            // then
+            Assert.IsFalse(result.IsSkippable);
+            Assert.AreEqual(5,result.Nodes.Count);
+            Assert.AreEqual(1,result.StartNodes.Count);
+            Assert.AreEqual(1,result.EndNodes.Count);
+
+            var node0 = result.Nodes[0];
+            var node1 = result.Nodes[1];
+            var node2 = result.Nodes[2];
+            var node3 = result.Nodes[3];
+            var node4 = result.Nodes[4];
+
+            Assert.IsTrue(result.StartNodes.Contains(node0));
+            Assert.IsFalse(result.EndNodes.Contains(node0));
+            Assert.AreEqual(2, node0.NextNodes.Count);
+            Assert.Contains(node1,node0.NextNodes.ToList());
+            Assert.Contains(node2,node0.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node1));
+            Assert.IsFalse(result.EndNodes.Contains(node1));
+            Assert.AreEqual(1, node1.NextNodes.Count);
+            Assert.Contains(node2,node1.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node2));
+            Assert.IsFalse(result.EndNodes.Contains(node2));
+            Assert.AreEqual(2, node2.NextNodes.Count);
+            Assert.Contains(node3,node2.NextNodes.ToList());
+            Assert.Contains(node4,node2.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node3));
+            Assert.IsFalse(result.EndNodes.Contains(node3));
+            Assert.AreEqual(1, node3.NextNodes.Count);
+            Assert.Contains(node4,node3.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node4));
+            Assert.IsTrue(result.EndNodes.Contains(node4));
+            Assert.AreEqual(0, node4.NextNodes.Count);
+        }
+
+        [Test]
+        public void SubsequentSkippableItemsYieldsComplexGraph()
+        {
+            // given
+            var expr = new Expression(
+                new LiteralSubExpression("a"),
+                new LiteralSubExpression("b", isSkippable: true),
+                new LiteralSubExpression("c", isSkippable: true),
+                new LiteralSubExpression("d", isSkippable: true),
+                new LiteralSubExpression("e"));
+            var gc = new GrammarCompiler();
+            // when
+            var result = gc.GetNodesFromExpression(expr, null);
+            // then
+            Assert.IsFalse(result.IsSkippable);
+            Assert.AreEqual(5,result.Nodes.Count);
+            Assert.AreEqual(1,result.StartNodes.Count);
+            Assert.AreEqual(1,result.EndNodes.Count);
+
+            var node0 = result.Nodes[0];
+            var node1 = result.Nodes[1];
+            var node2 = result.Nodes[2];
+            var node3 = result.Nodes[3];
+            var node4 = result.Nodes[4];
+
+            Assert.IsTrue(result.StartNodes.Contains(node0));
+            Assert.IsFalse(result.EndNodes.Contains(node0));
+            Assert.AreEqual(4, node0.NextNodes.Count);
+            Assert.Contains(node1,node0.NextNodes.ToList());
+            Assert.Contains(node2,node0.NextNodes.ToList());
+            Assert.Contains(node3,node0.NextNodes.ToList());
+            Assert.Contains(node4,node0.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node1));
+            Assert.IsFalse(result.EndNodes.Contains(node1));
+            Assert.AreEqual(3, node1.NextNodes.Count);
+            Assert.Contains(node2,node1.NextNodes.ToList());
+            Assert.Contains(node3,node1.NextNodes.ToList());
+            Assert.Contains(node4,node1.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node2));
+            Assert.IsFalse(result.EndNodes.Contains(node2));
+            Assert.AreEqual(2, node2.NextNodes.Count);
+            Assert.Contains(node3,node2.NextNodes.ToList());
+            Assert.Contains(node4,node2.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node3));
+            Assert.IsFalse(result.EndNodes.Contains(node3));
+            Assert.AreEqual(1, node3.NextNodes.Count);
+            Assert.Contains(node4,node3.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node4));
+            Assert.IsTrue(result.EndNodes.Contains(node4));
+            Assert.AreEqual(0, node4.NextNodes.Count);
+        }
+
+        [Test]
+        public void SubsequentSkippableItemsYieldsComplexGraph2()
+        {
+            // given
+            var expr = new Expression(
+                new LiteralSubExpression("a"),
+                new LiteralSubExpression("b", isSkippable: true),
+                new LiteralSubExpression("c", isSkippable: true),
+                new LiteralSubExpression("d"),
+                new LiteralSubExpression("e"));
+            var gc = new GrammarCompiler();
+            // when
+            var result = gc.GetNodesFromExpression(expr, null);
+            // then
+            Assert.IsFalse(result.IsSkippable);
+            Assert.AreEqual(5,result.Nodes.Count);
+            Assert.AreEqual(1,result.StartNodes.Count);
+            Assert.AreEqual(1,result.EndNodes.Count);
+
+            var node0 = result.Nodes[0];
+            var node1 = result.Nodes[1];
+            var node2 = result.Nodes[2];
+            var node3 = result.Nodes[3];
+            var node4 = result.Nodes[4];
+
+            Assert.IsTrue(result.StartNodes.Contains(node0));
+            Assert.IsFalse(result.EndNodes.Contains(node0));
+            Assert.AreEqual(3, node0.NextNodes.Count);
+            Assert.Contains(node1,node0.NextNodes.ToList());
+            Assert.Contains(node2,node0.NextNodes.ToList());
+            Assert.Contains(node3,node0.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node1));
+            Assert.IsFalse(result.EndNodes.Contains(node1));
+            Assert.AreEqual(2, node1.NextNodes.Count);
+            Assert.Contains(node2,node1.NextNodes.ToList());
+            Assert.Contains(node3,node1.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node2));
+            Assert.IsFalse(result.EndNodes.Contains(node2));
+            Assert.AreEqual(1, node2.NextNodes.Count);
+            Assert.Contains(node3,node2.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node3));
+            Assert.IsFalse(result.EndNodes.Contains(node3));
+            Assert.AreEqual(1, node3.NextNodes.Count);
+            Assert.Contains(node4,node3.NextNodes.ToList());
+
+            Assert.IsFalse(result.StartNodes.Contains(node4));
+            Assert.IsTrue(result.EndNodes.Contains(node4));
+            Assert.AreEqual(0, node4.NextNodes.Count);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Giza.Test/GrammarCompilerT/GetNodesFromOrExpressionTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/GrammarCompilerT/GetNodesFromOrExpressionTest.cs
@@ -1,0 +1,176 @@
+
+// MetaphysicsIndustries.Giza - A Parsing System
+// Copyright (C) 2008-2021 Metaphysics Industries, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+// USA
+
+using System.Linq;
+using NUnit.Framework;
+
+namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
+{
+    [TestFixture]
+    public class GetNodesFromOrExpressionTest
+    {
+        [Test]
+        public void SingleExprYieldsSimpleNodeBundle()
+        {
+            // given
+            var orexpr = new OrExpression(
+                new[]
+                {
+                    new Expression(
+                        new LiteralSubExpression("a"))
+                });
+            var gc = new GrammarCompiler();
+            // precondition
+            Assert.IsFalse(orexpr.IsRepeatable);
+            Assert.IsFalse(orexpr.IsSkippable);
+            // when
+            var result = gc.GetNodesFromOrExpression(orexpr, null);
+            // then
+            Assert.AreEqual(1,result.StartNodes.Count);
+            Assert.AreEqual(1,result.EndNodes.Count);
+            Assert.AreEqual(1,result.Nodes.Count);
+            var node = result.Nodes[0];
+            Assert.Contains(node, result.StartNodes.ToList());
+            Assert.Contains(node, result.EndNodes.ToList());
+            Assert.IsFalse(result.IsSkippable);
+        }
+
+        [Test]
+        public void TwoExprsYieldTwoMutuallyExclusiveNodes()
+        {
+            // given
+            var orexpr = new OrExpression(
+                new[]
+                {
+                    new Expression(
+                        new LiteralSubExpression("a")),
+                    new Expression(
+                        new LiteralSubExpression("b")),
+                });
+            var gc = new GrammarCompiler();
+            // precondition
+            Assert.IsFalse(orexpr.IsRepeatable);
+            Assert.IsFalse(orexpr.IsSkippable);
+            // when
+            var result = gc.GetNodesFromOrExpression(orexpr, null);
+            // then
+            Assert.AreEqual(2,result.StartNodes.Count);
+            Assert.AreEqual(2,result.EndNodes.Count);
+            Assert.AreEqual(2,result.Nodes.Count);
+            var node0 = result.Nodes[0];
+            Assert.Contains(node0, result.StartNodes.ToList());
+            Assert.Contains(node0, result.EndNodes.ToList());
+            var node1 = result.Nodes[1];
+            Assert.Contains(node1, result.StartNodes.ToList());
+            Assert.Contains(node1, result.EndNodes.ToList());
+            Assert.IsFalse(result.IsSkippable);
+        }
+
+        [Test]
+        public void TwoSequentialSubExpressionsYieldNotBothStartAndEndNodes()
+        {
+            // given
+            var orexpr = new OrExpression(
+                new[]
+                {
+                    new Expression(
+                        new LiteralSubExpression("a"),
+                        new LiteralSubExpression("b"))
+                });
+            var gc = new GrammarCompiler();
+            // precondition
+            Assert.IsFalse(orexpr.IsRepeatable);
+            Assert.IsFalse(orexpr.IsSkippable);
+            // when
+            var result = gc.GetNodesFromOrExpression(orexpr, null);
+            // then
+            Assert.AreEqual(1,result.StartNodes.Count);
+            Assert.AreEqual(1,result.EndNodes.Count);
+            Assert.AreEqual(2,result.Nodes.Count);
+            var node0 = result.Nodes[0];
+            Assert.Contains(node0, result.StartNodes.ToList());
+            Assert.IsFalse(result.EndNodes.Contains(node0));
+            var node1 = result.Nodes[1];
+            Assert.IsFalse(result.StartNodes.Contains(node1));
+            Assert.Contains(node1, result.EndNodes.ToList());
+            Assert.IsFalse(result.IsSkippable);
+        }
+
+        [Test]
+        public void SkippableFirstSubExpressionsYieldsSecondNodeAlsoStartNode()
+        {
+            // given
+            var orexpr = new OrExpression(
+                new[]
+                {
+                    new Expression(
+                        new LiteralSubExpression("a", isSkippable: true),
+                        new LiteralSubExpression("b"))
+                });
+            var gc = new GrammarCompiler();
+            // precondition
+            Assert.IsFalse(orexpr.IsRepeatable);
+            Assert.IsFalse(orexpr.IsSkippable);
+            // when
+            var result = gc.GetNodesFromOrExpression(orexpr, null);
+            // then
+            Assert.AreEqual(2,result.StartNodes.Count);
+            Assert.AreEqual(1,result.EndNodes.Count);
+            Assert.AreEqual(2,result.Nodes.Count);
+            var node0 = result.Nodes[0];
+            Assert.Contains(node0, result.StartNodes.ToList());
+            Assert.IsFalse(result.EndNodes.Contains(node0));
+            var node1 = result.Nodes[1];
+            Assert.Contains(node1, result.StartNodes.ToList());
+            Assert.Contains(node1, result.EndNodes.ToList());
+            Assert.IsFalse(result.IsSkippable);
+        }
+
+        [Test]
+        public void SkippableSecondSubExpressionsYieldsFirstNodeAlsoEndNode()
+        {
+            // given
+            var orexpr = new OrExpression(
+                // ('a' | 'b'?)
+                new[]
+                {
+                    new Expression(
+                        new LiteralSubExpression("a"),
+                        new LiteralSubExpression("b", isSkippable: true))
+                });
+            var gc = new GrammarCompiler();
+            // precondition
+            Assert.IsFalse(orexpr.IsRepeatable);
+            Assert.IsFalse(orexpr.IsSkippable);
+            // when
+            var result = gc.GetNodesFromOrExpression(orexpr, null);
+            // then
+            Assert.AreEqual(1,result.StartNodes.Count);
+            Assert.AreEqual(2,result.EndNodes.Count);
+            Assert.AreEqual(2,result.Nodes.Count);
+            var node0 = result.Nodes[0];
+            Assert.Contains(node0, result.StartNodes.ToList());
+            Assert.Contains(node0, result.EndNodes.ToList());
+            var node1 = result.Nodes[1];
+            Assert.IsFalse(result.StartNodes.Contains(node1));
+            Assert.Contains(node1, result.EndNodes.ToList());
+            Assert.IsFalse(result.IsSkippable);
+        }
+    }
+}

--- a/MetaphysicsIndustries.Giza.Test/MetaphysicsIndustries.Giza.Test.csproj
+++ b/MetaphysicsIndustries.Giza.Test/MetaphysicsIndustries.Giza.Test.csproj
@@ -37,6 +37,8 @@
   <ItemGroup>
     <Compile Include="CSharpPathTest.cs" />
     <Compile Include="DefinitionTest.cs" />
+    <Compile Include="GrammarCompilerT\GetNodesFromExpressionTest.cs" />
+    <Compile Include="GrammarCompilerT\GetNodesFromOrExpressionTest.cs" />
     <Compile Include="ImportTest.cs" />
     <Compile Include="ImportTransformTest.cs" />
     <Compile Include="MockFileSource.cs" />

--- a/ParserError.cs
+++ b/ParserError.cs
@@ -102,7 +102,7 @@ namespace MetaphysicsIndustries.Giza
                 var expects = new List<string>();
                 foreach (var enode in ExpectedNodes)
                 {
-                    expects.Add(((DefRefNode)ExpectedNodes.First()).DefRef.Name);
+                    expects.Add(((DefRefNode)enode).DefRef.Name);
                 }
                 StringBuilder sb = new StringBuilder();
                 sb.Append("Expected ");

--- a/todo.txt
+++ b/todo.txt
@@ -1,3 +1,20 @@
+
+parsing bug:
+    subsequent skippable expression items aren't collectively skippable
+    looks like the nodes aren't getting their nexts set correctly beyond the first follower
+
+    >>> x = '[' 'a'? 'b'? ']';
+    >>> parse x '[ab]'
+    There is 1 valid parse of the input.
+    >>> parse x '[a]'
+    There is 1 valid parse of the input.
+    >>> parse x '[b]'
+    There is 1 valid parse of the input.
+    >>> parse x '[]'
+    There are errors in the input:
+      Invalid token ']' at position 1,2 (index 1). Expected $implicit literal a, or $implicit literal b
+
+
 coherent error handling
     error lists or exceptions?
     return errors or always use a parameters?

--- a/todo.txt
+++ b/todo.txt
@@ -1,20 +1,3 @@
-
-parsing bug:
-    subsequent skippable expression items aren't collectively skippable
-    looks like the nodes aren't getting their nexts set correctly beyond the first follower
-
-    >>> x = '[' 'a'? 'b'? ']';
-    >>> parse x '[ab]'
-    There is 1 valid parse of the input.
-    >>> parse x '[a]'
-    There is 1 valid parse of the input.
-    >>> parse x '[b]'
-    There is 1 valid parse of the input.
-    >>> parse x '[]'
-    There are errors in the input:
-      Invalid token ']' at position 1,2 (index 1). Expected $implicit literal a, or $implicit literal b
-
-
 coherent error handling
     error lists or exceptions?
     return errors or always use a parameters?


### PR DESCRIPTION
This PR fixes a bug in the grammar compiler. In an expression, items are skippable, which means that if a skippable item does not appear in the input, that doesn't fail the parse as would be the case otherwise. If two or more skippable items appear in a row, then they should all likewise be considered optional. However, the construction of the graph was incorrectly preventing such items to be skipped as a group.

For example:

    >>> x = '[' 'a'? 'b'? ']';
    >>> parse x '[ab]'
    There is 1 valid parse of the input.
    >>> parse x '[a]'
    There is 1 valid parse of the input.
    >>> parse x '[b]'
    There is 1 valid parse of the input.
    >>> parse x '[]'
    There are errors in the input:
      Invalid token ']' at position 1,2 (index 1). Expected $implicit literal a, or $implicit literal b

That last example should have succeeded, given the definition `x` and the input.

This PR corrects the code that connects the nodes so that subsequent skippable items can all be skipped.

This PR also fixes a minor unrelated bug that had to do with certain error messages.
