### PR TITLE
Clean up tests

### DIFF
--- a/MetaphysicsIndustries.Giza.Test/CSharpPathTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/CSharpPathTest.cs
@@ -72,7 +72,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var a2 = Path.Combine(a1, toPath);
             var a3 = Path.GetFullPath(a2);
             // then
-            Assert.AreEqual("/path/to/another/file2.giza", a3);
+            Assert.That(a3, Is.EqualTo("/path/to/another/file2.giza"));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/CharacterSourceTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/CharacterSourceTest.cs
@@ -35,259 +35,265 @@ namespace MetaphysicsIndustries.Giza.Test
             //column 1234567 8 912345 61
             var cs = new CharacterSource(s);
 
-            Assert.AreEqual(0, cs.CurrentPosition.Index);
-            Assert.AreEqual(1, cs.CurrentPosition.Line);
-            Assert.AreEqual(1, cs.CurrentPosition.Column);
+            Assert.That(cs.CurrentPosition.Index, Is.EqualTo(0));
+            Assert.That(cs.CurrentPosition.Line, Is.EqualTo(1));
+            Assert.That(cs.CurrentPosition.Column, Is.EqualTo(1));
             var ies = cs.Peek();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
-            Assert.AreEqual(cs.CurrentPosition, ies.InputElements.First().Position);
-            Assert.AreEqual('O', ies.InputElements.First().Value);
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
+            Assert.That(ies.InputElements.First().Position,
+                Is.EqualTo(cs.CurrentPosition));
+            Assert.That(ies.InputElements.First().Value, Is.EqualTo('O'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             var ch = ies.InputElements.First();
 
-            Assert.AreEqual(0, ch.Position.Index);
-            Assert.AreEqual(1, ch.Position.Line);
-            Assert.AreEqual(1, ch.Position.Column);
-            Assert.AreEqual('O', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(0));
+            Assert.That(ch.Position.Line, Is.EqualTo(1));
+            Assert.That(ch.Position.Column, Is.EqualTo(1));
+            Assert.That(ch.Value, Is.EqualTo('O'));
 
-            Assert.AreEqual(1, cs.CurrentPosition.Index);
-            Assert.AreEqual(1, cs.CurrentPosition.Line);
-            Assert.AreEqual(2, cs.CurrentPosition.Column);
+            Assert.That(cs.CurrentPosition.Index, Is.EqualTo(1));
+            Assert.That(cs.CurrentPosition.Line, Is.EqualTo(1));
+            Assert.That(cs.CurrentPosition.Column, Is.EqualTo(2));
             ies = cs.Peek();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
-            Assert.AreEqual(cs.CurrentPosition, ies.InputElements.First().Position);
-            Assert.AreEqual('n', ies.InputElements.First().Value);
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
+            Assert.That(ies.InputElements.First().Position,
+                Is.EqualTo(cs.CurrentPosition));
+            Assert.That(ies.InputElements.First().Value, Is.EqualTo('n'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(1, ch.Position.Index);
-            Assert.AreEqual(1, ch.Position.Line);
-            Assert.AreEqual(2, ch.Position.Column);
-            Assert.AreEqual('n', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(1));
+            Assert.That(ch.Position.Line, Is.EqualTo(1));
+            Assert.That(ch.Position.Column, Is.EqualTo(2));
+            Assert.That(ch.Value, Is.EqualTo('n'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(2, ch.Position.Index);
-            Assert.AreEqual(1, ch.Position.Line);
-            Assert.AreEqual(3, ch.Position.Column);
-            Assert.AreEqual('e', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(2));
+            Assert.That(ch.Position.Line, Is.EqualTo(1));
+            Assert.That(ch.Position.Column, Is.EqualTo(3));
+            Assert.That(ch.Value, Is.EqualTo('e'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(3, ch.Position.Index);
-            Assert.AreEqual(1, ch.Position.Line);
-            Assert.AreEqual(4, ch.Position.Column);
-            Assert.AreEqual(' ', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(3));
+            Assert.That(ch.Position.Line, Is.EqualTo(1));
+            Assert.That(ch.Position.Column, Is.EqualTo(4));
+            Assert.That(ch.Value, Is.EqualTo(' '));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(4, ch.Position.Index);
-            Assert.AreEqual(1, ch.Position.Line);
-            Assert.AreEqual(5, ch.Position.Column);
-            Assert.AreEqual('t', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(4));
+            Assert.That(ch.Position.Line, Is.EqualTo(1));
+            Assert.That(ch.Position.Column, Is.EqualTo(5));
+            Assert.That(ch.Value, Is.EqualTo('t'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(5, ch.Position.Index);
-            Assert.AreEqual(1, ch.Position.Line);
-            Assert.AreEqual(6, ch.Position.Column);
-            Assert.AreEqual('w', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(5));
+            Assert.That(ch.Position.Line, Is.EqualTo(1));
+            Assert.That(ch.Position.Column, Is.EqualTo(6));
+            Assert.That(ch.Value, Is.EqualTo('w'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(6, ch.Position.Index);
-            Assert.AreEqual(1, ch.Position.Line);
-            Assert.AreEqual(7, ch.Position.Column);
-            Assert.AreEqual('o', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(6));
+            Assert.That(ch.Position.Line, Is.EqualTo(1));
+            Assert.That(ch.Position.Column, Is.EqualTo(7));
+            Assert.That(ch.Value, Is.EqualTo('o'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(7, ch.Position.Index);
-            Assert.AreEqual(1, ch.Position.Line);
-            Assert.AreEqual(8, ch.Position.Column);
-            Assert.AreEqual('\r', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(7));
+            Assert.That(ch.Position.Line, Is.EqualTo(1));
+            Assert.That(ch.Position.Column, Is.EqualTo(8));
+            Assert.That(ch.Value, Is.EqualTo('\r'));
 
-            Assert.AreEqual(8, cs.CurrentPosition.Index);
-            Assert.AreEqual(1, cs.CurrentPosition.Line);
-            Assert.AreEqual(9, cs.CurrentPosition.Column);
+            Assert.That(cs.CurrentPosition.Index, Is.EqualTo(8));
+            Assert.That(cs.CurrentPosition.Line, Is.EqualTo(1));
+            Assert.That(cs.CurrentPosition.Column, Is.EqualTo(9));
             ies = cs.Peek();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
-            Assert.AreEqual(cs.CurrentPosition, ies.InputElements.First().Position);
-            Assert.AreEqual('\n', ies.InputElements.First().Value);
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
+            Assert.That(ies.InputElements.First().Position,
+                Is.EqualTo(cs.CurrentPosition));
+            Assert.That(ies.InputElements.First().Value, Is.EqualTo('\n'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(8, ch.Position.Index);
-            Assert.AreEqual(1, ch.Position.Line);
-            Assert.AreEqual(9, ch.Position.Column);
-            Assert.AreEqual('\n', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(8));
+            Assert.That(ch.Position.Line, Is.EqualTo(1));
+            Assert.That(ch.Position.Column, Is.EqualTo(9));
+            Assert.That(ch.Value, Is.EqualTo('\n'));
 
-            Assert.AreEqual(9, cs.CurrentPosition.Index);
-            Assert.AreEqual(2, cs.CurrentPosition.Line);
-            Assert.AreEqual(1, cs.CurrentPosition.Column);
+            Assert.That(cs.CurrentPosition.Index, Is.EqualTo(9));
+            Assert.That(cs.CurrentPosition.Line, Is.EqualTo(2));
+            Assert.That(cs.CurrentPosition.Column, Is.EqualTo(1));
             ies = cs.Peek();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
-            Assert.AreEqual(cs.CurrentPosition, ies.InputElements.First().Position);
-            Assert.AreEqual('t', ies.InputElements.First().Value);
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
+            Assert.That(ies.InputElements.First().Position,
+                Is.EqualTo(cs.CurrentPosition));
+            Assert.That(ies.InputElements.First().Value, Is.EqualTo('t'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(9, ch.Position.Index);
-            Assert.AreEqual(2, ch.Position.Line);
-            Assert.AreEqual(1, ch.Position.Column);
-            Assert.AreEqual('t', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(9));
+            Assert.That(ch.Position.Line, Is.EqualTo(2));
+            Assert.That(ch.Position.Column, Is.EqualTo(1));
+            Assert.That(ch.Value, Is.EqualTo('t'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(10, ch.Position.Index);
-            Assert.AreEqual(2, ch.Position.Line);
-            Assert.AreEqual(2, ch.Position.Column);
-            Assert.AreEqual('h', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(10));
+            Assert.That(ch.Position.Line, Is.EqualTo(2));
+            Assert.That(ch.Position.Column, Is.EqualTo(2));
+            Assert.That(ch.Value, Is.EqualTo('h'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(11, ch.Position.Index);
-            Assert.AreEqual(2, ch.Position.Line);
-            Assert.AreEqual(3, ch.Position.Column);
-            Assert.AreEqual('r', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(11));
+            Assert.That(ch.Position.Line, Is.EqualTo(2));
+            Assert.That(ch.Position.Column, Is.EqualTo(3));
+            Assert.That(ch.Value, Is.EqualTo('r'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(12, ch.Position.Index);
-            Assert.AreEqual(2, ch.Position.Line);
-            Assert.AreEqual(4, ch.Position.Column);
-            Assert.AreEqual('e', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(12));
+            Assert.That(ch.Position.Line, Is.EqualTo(2));
+            Assert.That(ch.Position.Column, Is.EqualTo(4));
+            Assert.That(ch.Value, Is.EqualTo('e'));
 
-            Assert.AreEqual(13, cs.CurrentPosition.Index);
-            Assert.AreEqual(2, cs.CurrentPosition.Line);
-            Assert.AreEqual(5, cs.CurrentPosition.Column);
+            Assert.That(cs.CurrentPosition.Index, Is.EqualTo(13));
+            Assert.That(cs.CurrentPosition.Line, Is.EqualTo(2));
+            Assert.That(cs.CurrentPosition.Column, Is.EqualTo(5));
             ies = cs.Peek();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
-            Assert.AreEqual(cs.CurrentPosition, ies.InputElements.First().Position);
-            Assert.AreEqual('e', ies.InputElements.First().Value);
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
+            Assert.That(ies.InputElements.First().Position,
+                Is.EqualTo(cs.CurrentPosition));
+            Assert.That(ies.InputElements.First().Value, Is.EqualTo('e'));
 
             ies = cs.GetNextValue();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(13, ch.Position.Index);
-            Assert.AreEqual(2, ch.Position.Line);
-            Assert.AreEqual(5, ch.Position.Column);
-            Assert.AreEqual('e', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(13));
+            Assert.That(ch.Position.Line, Is.EqualTo(2));
+            Assert.That(ch.Position.Column, Is.EqualTo(5));
+            Assert.That(ch.Value, Is.EqualTo('e'));
 
-            Assert.AreEqual(14, cs.CurrentPosition.Index);
-            Assert.AreEqual(2, cs.CurrentPosition.Line);
-            Assert.AreEqual(6, cs.CurrentPosition.Column);
+            Assert.That(cs.CurrentPosition.Index, Is.EqualTo(14));
+            Assert.That(cs.CurrentPosition.Line, Is.EqualTo(2));
+            Assert.That(cs.CurrentPosition.Column, Is.EqualTo(6));
             ies = cs.Peek();
             Assert.IsFalse(ies.EndOfInput);
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
-            Assert.AreEqual(cs.CurrentPosition, ies.InputElements.First().Position);
-            Assert.AreEqual('\n', ies.InputElements.First().Value);
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
+            Assert.That(ies.InputElements.First().Position,
+                Is.EqualTo(cs.CurrentPosition));
+            Assert.That(ies.InputElements.First().Value, Is.EqualTo('\n'));
 
             Assert.IsFalse(cs.IsAtEnd);
 
@@ -296,17 +302,17 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             ch = ies.InputElements.First();
 
-            Assert.AreEqual(14, ch.Position.Index);
-            Assert.AreEqual(2, ch.Position.Line);
-            Assert.AreEqual(6, ch.Position.Column);
-            Assert.AreEqual('\n', ch.Value);
+            Assert.That(ch.Position.Index, Is.EqualTo(14));
+            Assert.That(ch.Position.Line, Is.EqualTo(2));
+            Assert.That(ch.Position.Column, Is.EqualTo(6));
+            Assert.That(ch.Value, Is.EqualTo('\n'));
 
-            Assert.AreEqual(15, cs.CurrentPosition.Index);
-            Assert.AreEqual(3, cs.CurrentPosition.Line);
-            Assert.AreEqual(1, cs.CurrentPosition.Column);
+            Assert.That(cs.CurrentPosition.Index, Is.EqualTo(15));
+            Assert.That(cs.CurrentPosition.Line, Is.EqualTo(3));
+            Assert.That(cs.CurrentPosition.Column, Is.EqualTo(1));
 
             Assert.IsTrue(cs.IsAtEnd);
         }

--- a/MetaphysicsIndustries.Giza.Test/CommandLineTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/CommandLineTest.cs
@@ -60,15 +60,16 @@ namespace MetaphysicsIndustries.Giza.Test
             giza.Program.Main(new string[] { "check", "--tokenized", "-" });
 
             // assertions
-            Assert.AreEqual("", newStderr.ToString());
-            Assert.AreEqual(
-                "There are 5 definitions in the grammar:\n" +
-                "  expr\n" +
-                "  value\n" +
-                "  number\n" +
-                "  varref\n" +
-                "  $implicit char class *+-/\n",
-                newStdout.ToString());
+            Assert.That(newStderr.ToString(), Is.EqualTo(""));
+            Assert.That(
+                newStdout.ToString(),
+                Is.EqualTo(
+                    "There are 5 definitions in the grammar:\n" +
+                    "  expr\n" +
+                    "  value\n" +
+                    "  number\n" +
+                    "  varref\n" +
+                    "  $implicit char class *+-/\n"));
         }
 
         class MultipleStdIn : TextReader
@@ -169,10 +170,10 @@ namespace MetaphysicsIndustries.Giza.Test
             giza.Program.Main(new string[] { "parse", "-", "expr", "-" });
 
             // assertions
-            Assert.AreEqual("", newStderr.ToString());
-            Assert.AreEqual(
-                "There is 1 valid parse of the input.\n",
-                newStdout.ToString());
+            Assert.That(newStderr.ToString(), Is.EqualTo(""));
+            Assert.That(
+                newStdout.ToString(),
+                Is.EqualTo("There is 1 valid parse of the input.\n"));
         }
 
         [Test]
@@ -199,10 +200,9 @@ namespace MetaphysicsIndustries.Giza.Test
             giza.Program.Main(new string[] { "span", "-", "expr", "-" });
 
             // assertions
-            Assert.AreEqual("", newStderr.ToString());
-            Assert.AreEqual(
-                "There is 1 valid span of the input.\n",
-                newStdout.ToString());
+            Assert.That(newStderr.ToString(), Is.EqualTo(""));
+            Assert.That(newStdout.ToString(),
+                Is.EqualTo("There is 1 valid span of the input.\n"));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/DefinitionCheckerTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/DefinitionCheckerTest.cs
@@ -165,11 +165,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errorEnu);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<DefinitionError>(errors[0]);
             var err = (DefinitionError)errors[0];
-            Assert.AreEqual(DefinitionError.NodeHasNoPathFromStart, err.ErrorType);
-            Assert.AreSame(n2, err.Node);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(DefinitionError.NodeHasNoPathFromStart));
+            Assert.That(err.Node, Is.SameAs(n2));
         }
 
         [Test]
@@ -201,11 +202,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errorEnu);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<DefinitionError>(errors[0]);
             var err = (DefinitionError)errors[0];
-            Assert.AreEqual(DefinitionError.NodeHasNoPathToEnd, err.ErrorType);
-            Assert.AreSame(n2, err.Node);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(DefinitionError.NodeHasNoPathToEnd));
+            Assert.That(err.Node, Is.SameAs(n2));
         }
 
         [Test]
@@ -233,11 +235,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errorEnu);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<DefinitionError>(errors[0]);
             var err = (DefinitionError)errors[0];
-            Assert.AreEqual(DefinitionError.NextNodeLinksOutsideOfDefinition, err.ErrorType);
-            Assert.AreSame(n1, err.Node);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(DefinitionError.NextNodeLinksOutsideOfDefinition));
+            Assert.That(err.Node, Is.SameAs(n1));
         }
 
         [Test]
@@ -261,11 +264,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errorEnu);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<DefinitionError>(errors[0]);
             var err = (DefinitionError)errors[0];
-            Assert.AreEqual(DefinitionError.NextNodeLinksOutsideOfDefinition, err.ErrorType);
-            Assert.AreSame(n1, err.Node);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(DefinitionError.NextNodeLinksOutsideOfDefinition));
+            Assert.That(err.Node, Is.SameAs(n1));
         }
 
         [Test]
@@ -294,11 +298,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errorEnu);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<DefinitionError>(errors[0]);
             var err = (DefinitionError)errors[0];
-            Assert.AreEqual(DefinitionError.StartNodeHasWrongParentDefinition, err.ErrorType);
-            Assert.AreSame(n2, err.Node);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(DefinitionError.StartNodeHasWrongParentDefinition));
+            Assert.That(err.Node, Is.SameAs(n2));
         }
 
         [Test]
@@ -323,11 +328,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errorEnu);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<DefinitionError>(errors[0]);
             var err = (DefinitionError)errors[0];
-            Assert.AreEqual(DefinitionError.StartNodeHasWrongParentDefinition, err.ErrorType);
-            Assert.AreSame(n2, err.Node);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(DefinitionError.StartNodeHasWrongParentDefinition));
+            Assert.That(err.Node, Is.SameAs(n2));
         }
 
         [Test]
@@ -356,11 +362,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errorEnu);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<DefinitionError>(errors[0]);
             var err = (DefinitionError)errors[0];
-            Assert.AreEqual(DefinitionError.EndNodeHasWrongParentDefinition, err.ErrorType);
-            Assert.AreSame(n2, err.Node);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(DefinitionError.EndNodeHasWrongParentDefinition));
+            Assert.That(err.Node, Is.SameAs(n2));
         }
 
         [Test]
@@ -385,11 +392,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errorEnu);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<DefinitionError>(errors[0]);
             var err = (DefinitionError)errors[0];
-            Assert.AreEqual(DefinitionError.EndNodeHasWrongParentDefinition, err.ErrorType);
-            Assert.AreSame(n2, err.Node);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(DefinitionError.EndNodeHasWrongParentDefinition));
+            Assert.That(err.Node, Is.SameAs(n2));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Giza.Test/DefinitionRendererTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/DefinitionRendererTest.cs
@@ -45,7 +45,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var dr = new DefinitionRenderer();
             var result = dr.RenderDefinitionExprsAsGrammarText(g.Definitions);
 
-            Assert.AreEqual(input, result);
+            Assert.That(result, Is.EqualTo(input));
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var dr = new DefinitionRenderer();
             var result = dr.RenderDefinitionExprsAsGrammarText(g.Definitions);
 
-            Assert.AreEqual(input, result);
+            Assert.That(result, Is.EqualTo(input));
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var dr = new DefinitionRenderer();
             var result = dr.RenderDefinitionExprsAsGrammarText(g.Definitions);
 
-            Assert.AreEqual(input, result);
+            Assert.That(result, Is.EqualTo(input));
         }
 
         [Test]
@@ -105,7 +105,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var dr = new DefinitionRenderer();
             var result = dr.RenderDefinitionExprsAsGrammarText(g.Definitions);
 
-            Assert.AreEqual(input, result);
+            Assert.That(result, Is.EqualTo(input));
         }
 
         // TODO: test C# output

--- a/MetaphysicsIndustries.Giza.Test/DefinitionTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/DefinitionTest.cs
@@ -31,7 +31,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = new Definition();
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual("", result.Name);
+            Assert.That(result.Name, Is.EqualTo(""));
             Assert.IsEmpty(result.Directives);
             Assert.IsNotNull(result.Expr);
             Assert.IsEmpty(result.Expr.Items);
@@ -53,16 +53,16 @@ namespace MetaphysicsIndustries.Giza.Test
                 "source1");
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual("def1", result.Name);
+            Assert.That(result.Name, Is.EqualTo("def1"));
             Assert.IsNotEmpty(result.Directives);
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.Atomic));
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.IgnoreCase));
             Assert.IsNotNull(result.Expr);
-            Assert.AreSame(expr, result.Expr);
+            Assert.That(result.Expr, Is.SameAs(expr));
             Assert.IsTrue(result.IsImported);
-            Assert.AreEqual("source1", result.Source);
+            Assert.That(result.Source, Is.EqualTo("source1"));
         }
 
         [Test]
@@ -80,14 +80,14 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = def.Clone();
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual("def1", result.Name);
+            Assert.That(result.Name, Is.EqualTo("def1"));
             Assert.IsNotEmpty(result.Directives);
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.Atomic));
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.IgnoreCase));
             Assert.IsNotNull(result.Expr);
-            Assert.AreSame(expr, result.Expr);
+            Assert.That(result.Expr, Is.SameAs(expr));
             Assert.IsTrue(result.IsImported);
         }
 
@@ -106,14 +106,14 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = def.Clone(newName: "def2");
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual("def2", result.Name);
+            Assert.That(result.Name, Is.EqualTo("def2"));
             Assert.IsNotEmpty(result.Directives);
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.Atomic));
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.IgnoreCase));
             Assert.IsNotNull(result.Expr);
-            Assert.AreSame(expr, result.Expr);
+            Assert.That(result.Expr, Is.SameAs(expr));
             Assert.IsTrue(result.IsImported);
         }
 
@@ -133,7 +133,7 @@ namespace MetaphysicsIndustries.Giza.Test
                 newDirectives: new []{DefinitionDirective.MindWhitespace});
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual("def1", result.Name);
+            Assert.That(result.Name, Is.EqualTo("def1"));
             Assert.IsNotEmpty(result.Directives);
             Assert.IsFalse(
                 result.Directives.Contains(DefinitionDirective.Atomic));
@@ -143,7 +143,7 @@ namespace MetaphysicsIndustries.Giza.Test
                 result.Directives.Contains(
                     DefinitionDirective.MindWhitespace));
             Assert.IsNotNull(result.Expr);
-            Assert.AreSame(expr, result.Expr);
+            Assert.That(result.Expr, Is.SameAs(expr));
             Assert.IsTrue(result.IsImported);
         }
 
@@ -164,15 +164,15 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = def.Clone(newExpr: expr2);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual("def1", result.Name);
+            Assert.That(result.Name, Is.EqualTo("def1"));
             Assert.IsNotEmpty(result.Directives);
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.Atomic));
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.IgnoreCase));
             Assert.IsNotNull(result.Expr);
-            Assert.AreNotSame(expr1, result.Expr);
-            Assert.AreSame(expr2, result.Expr);
+            Assert.That(result.Expr, Is.Not.SameAs(expr1));
+            Assert.That(result.Expr, Is.SameAs(expr2));
             Assert.IsTrue(result.IsImported);
         }
 
@@ -191,14 +191,14 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = def.Clone(newIsImported: false);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual("def1", result.Name);
+            Assert.That(result.Name, Is.EqualTo("def1"));
             Assert.IsNotEmpty(result.Directives);
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.Atomic));
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.IgnoreCase));
             Assert.IsNotNull(result.Expr);
-            Assert.AreSame(expr, result.Expr);
+            Assert.That(result.Expr, Is.SameAs(expr));
             Assert.IsFalse(result.IsImported);
         }
 
@@ -217,14 +217,14 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = def.Clone(newIsImported: true);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual("def1", result.Name);
+            Assert.That(result.Name, Is.EqualTo("def1"));
             Assert.IsNotEmpty(result.Directives);
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.Atomic));
             Assert.IsTrue(
                 result.Directives.Contains(DefinitionDirective.IgnoreCase));
             Assert.IsNotNull(result.Expr);
-            Assert.AreSame(expr, result.Expr);
+            Assert.That(result.Expr, Is.SameAs(expr));
             Assert.IsTrue(result.IsImported);
         }
 
@@ -236,7 +236,7 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = def.ToString();
             // then
-            Assert.AreEqual("Definition def1", result);
+            Assert.That(result, Is.EqualTo("Definition def1"));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/ExpressionCheckerTest.Directives.cs
+++ b/MetaphysicsIndustries.Giza.Test/ExpressionCheckerTest.Directives.cs
@@ -40,10 +40,13 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionsForSpanning(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedDirectiveInNonTokenizedGrammar, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.
+                    TokenizedDirectiveInNonTokenizedGrammar));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
-            Assert.AreSame(defs[0], (errors[0] as ExpressionError).Definition);
+            Assert.That((errors[0] as ExpressionError).Definition,
+                Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -61,10 +64,13 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionsForSpanning(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedDirectiveInNonTokenizedGrammar, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(
+                    ExpressionError.TokenizedDirectiveInNonTokenizedGrammar));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
-            Assert.AreSame(defs[0], (errors[0] as ExpressionError).Definition);
+            Assert.That((errors[0] as ExpressionError).Definition,
+                Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -82,12 +88,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionsForSpanning(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedDirectiveInNonTokenizedGrammar, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(
+                    ExpressionError.TokenizedDirectiveInNonTokenizedGrammar));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
-            Assert.AreSame(defs[0], (errors[0] as ExpressionError).Definition);
+            Assert.That((errors[0] as ExpressionError).Definition,
+                Is.SameAs(defs[0]));
         }
-
 
         [Test()]
         public void TestMixedTokenizedDirectives1()
@@ -105,11 +113,12 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.MixedTokenizedDirectives, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.MixedTokenizedDirectives));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -128,11 +137,12 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.MixedTokenizedDirectives, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.MixedTokenizedDirectives));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -151,11 +161,12 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.MixedTokenizedDirectives, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.MixedTokenizedDirectives));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test]
@@ -173,11 +184,12 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.AtomicInNonTokenDefinition, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.AtomicInNonTokenDefinition));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test]
@@ -195,11 +207,13 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.MindWhitespaceInNonTokenDefinition, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(
+                    ExpressionError.MindWhitespaceInNonTokenDefinition));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test]
@@ -218,11 +232,12 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.AtomicInTokenDefinition, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.AtomicInTokenDefinition));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test]
@@ -242,7 +257,7 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -261,11 +276,12 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.AtomicInCommentDefinition, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.AtomicInCommentDefinition));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test]
@@ -284,11 +300,13 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.MindWhitespaceInTokenizedDefinition, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(
+                    ExpressionError.MindWhitespaceInTokenizedDefinition));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test]
@@ -307,11 +325,13 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.MindWhitespaceInTokenizedDefinition, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(
+                    ExpressionError.MindWhitespaceInTokenizedDefinition));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test]
@@ -330,11 +350,13 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.MindWhitespaceInTokenizedDefinition, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(
+                    ExpressionError.MindWhitespaceInTokenizedDefinition));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/ExpressionCheckerTest.DirectivesAndDefRefs.cs
+++ b/MetaphysicsIndustries.Giza.Test/ExpressionCheckerTest.DirectivesAndDefRefs.cs
@@ -62,13 +62,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedReferencesToken, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.TokenizedReferencesToken));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test]
@@ -91,7 +92,7 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -114,13 +115,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedReferencesComment, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.TokenizedReferencesComment));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test]
@@ -142,13 +144,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedReferencesNonToken, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.TokenizedReferencesNonToken));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test]
@@ -171,13 +174,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedReferencesToken, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.TokenizedReferencesToken));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test]
@@ -200,7 +204,7 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -223,13 +227,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedReferencesComment, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.TokenizedReferencesComment));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test()]
@@ -251,13 +256,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedReferencesNonToken, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.TokenizedReferencesNonToken));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test]
@@ -280,13 +286,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedReferencesToken, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.TokenizedReferencesToken));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test]
@@ -309,7 +316,7 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -332,13 +339,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedReferencesComment, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.TokenizedReferencesComment));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test]
@@ -360,13 +368,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.TokenizedReferencesNonToken, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.TokenizedReferencesNonToken));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test]
@@ -388,7 +397,7 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -410,13 +419,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.NonTokenReferencesSubtoken, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.NonTokenReferencesSubtoken));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test()]
@@ -438,13 +448,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.NonTokenReferencesComment, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.NonTokenReferencesComment));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreEqual(null, err.Expression);
-            Assert.AreSame(defs[1].Expr.Items[0], err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
+            Assert.That(err.Expression, Is.EqualTo(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defs[1].Expr.Items[0]));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
         }
 
         [Test]
@@ -467,7 +478,7 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitionForParsing(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/ExpressionCheckerTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/ExpressionCheckerTest.cs
@@ -62,12 +62,13 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var e = (ExpressionError)errors[0];
-            Assert.AreEqual(ExpressionError.ReusedExpression, e.ErrorType);
-            Assert.AreSame(expr, e.Expression);
-            Assert.AreSame(defs[1], e.Definition);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ExpressionError.ReusedExpression));
+            Assert.That(e.Expression, Is.SameAs(expr));
+            Assert.That(e.Definition, Is.SameAs(defs[1]));
         }
 
         [Test()]
@@ -93,12 +94,13 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var e = (ExpressionError)errors[0];
-            Assert.AreEqual(ExpressionError.ReusedExpressionItem, e.ErrorType);
-            Assert.AreSame(literal, e.ExpressionItem);
-            Assert.AreSame(defs[1], e.Definition);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ExpressionError.ReusedExpressionItem));
+            Assert.That(e.ExpressionItem, Is.SameAs(literal));
+            Assert.That(e.Definition, Is.SameAs(defs[1]));
         }
 
         [Test()]
@@ -121,12 +123,13 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var e = (ExpressionError)errors[0];
-            Assert.AreEqual(ExpressionError.ReusedExpressionItem, e.ErrorType);
-            Assert.AreSame(literal, e.ExpressionItem);
-            Assert.AreSame(defs[0], e.Definition);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ExpressionError.ReusedExpressionItem));
+            Assert.That(e.ExpressionItem, Is.SameAs(literal));
+            Assert.That(e.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -154,12 +157,13 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var e = (ExpressionError)errors[0];
-            Assert.AreEqual(ExpressionError.ReusedExpression, e.ErrorType);
-            Assert.AreSame(expr, e.Expression);
-            Assert.AreSame(defs[0], e.Definition);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ExpressionError.ReusedExpression));
+            Assert.That(e.Expression, Is.SameAs(expr));
+            Assert.That(e.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -185,13 +189,14 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var e = (ExpressionError)errors[0];
-            Assert.AreEqual(ExpressionError.ReusedExpressionItem, e.ErrorType);
-            Assert.AreSame(null, e.Expression);
-            Assert.AreSame(orexpr, e.ExpressionItem);
-            Assert.AreSame(defs[0], e.Definition);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ExpressionError.ReusedExpressionItem));
+            Assert.That(e.Expression, Is.SameAs(null));
+            Assert.That(e.ExpressionItem, Is.SameAs(orexpr));
+            Assert.That(e.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -213,11 +218,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var e = (ExpressionError)errors[0];
-            Assert.AreEqual(ExpressionError.NullOrEmptyDefinitionName, e.ErrorType);
-            Assert.AreSame(defs[0], e.Definition);
+            Assert.That(e.ErrorType,
+             Is.EqualTo(ExpressionError.NullOrEmptyDefinitionName));
+            Assert.That(e.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -239,11 +245,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var e = (ExpressionError)errors[0];
-            Assert.AreEqual(ExpressionError.NullOrEmptyDefinitionName, e.ErrorType);
-            Assert.AreSame(defs[0], e.Definition);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ExpressionError.NullOrEmptyDefinitionName));
+            Assert.That(e.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -259,13 +266,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.EmptyExpressionItems, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.EmptyExpressionItems));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(defs[0].Expr, err.Expression);
-            Assert.AreSame(null, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(defs[0].Expr));
+            Assert.That(err.ExpressionItem, Is.SameAs(null));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -287,13 +295,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.EmptyExpressionItems, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.EmptyExpressionItems));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(expr, err.Expression);
-            Assert.AreSame(null, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(expr));
+            Assert.That(err.ExpressionItem, Is.SameAs(null));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -312,12 +321,13 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.EmptyOrexprExpressionList, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.EmptyOrexprExpressionList));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(orexpr, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.ExpressionItem, Is.SameAs(orexpr));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -339,13 +349,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.NullSubexprTag, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.NullSubexprTag));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(null, err.Expression);
-            Assert.AreSame(literal, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(literal));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -364,13 +375,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.NullOrEmptyDefrefName, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.NullOrEmptyDefrefName));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(null, err.Expression);
-            Assert.AreSame(defref, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defref));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -389,13 +401,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.NullOrEmptyDefrefName, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.NullOrEmptyDefrefName));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(null, err.Expression);
-            Assert.AreSame(defref, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defref));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -414,13 +427,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.NullOrEmptyLiteralValue, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.NullOrEmptyLiteralValue));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(null, err.Expression);
-            Assert.AreSame(literal, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(literal));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -439,13 +453,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.NullOrEmptyLiteralValue, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.NullOrEmptyLiteralValue));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(null, err.Expression);
-            Assert.AreSame(literal, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(literal));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -464,13 +479,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.NullOrEmptyCharClass, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.NullOrEmptyCharClass));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(null, err.Expression);
-            Assert.AreSame(cc, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(cc));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -489,13 +505,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.NullOrEmptyCharClass, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.NullOrEmptyCharClass));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(null, err.Expression);
-            Assert.AreSame(cc, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(cc));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -516,14 +533,15 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.DuplicateDefinitionName, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.DuplicateDefinitionName));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(null, err.Expression);
-            Assert.AreSame(null, err.ExpressionItem);
-            Assert.AreSame(defs[1], err.Definition);
-            Assert.AreEqual(1, err.Index);
+            Assert.That(err.Expression, Is.SameAs(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(null));
+            Assert.That(err.Definition, Is.SameAs(defs[1]));
+            Assert.That(err.Index, Is.EqualTo(1));
         }
 
         [Test()]
@@ -552,13 +570,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.AllItemsSkippable, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.AllItemsSkippable));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(expr, err.Expression);
-            Assert.AreSame(null, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(expr));
+            Assert.That(err.ExpressionItem, Is.SameAs(null));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
 
@@ -587,13 +606,14 @@ namespace MetaphysicsIndustries.Giza.Test
 //            List<Error> errors = ec.CheckDefinitionInfos(defs);
 //
 //            Assert.IsNotNull(errors);
-//            Assert.AreEqual(1, errors.Count);
-//            Assert.AreEqual(ExpressionChecker.Error.AllItemsSkippable, errors[0].ErrorType);
+//            Assert.That(errors.Count, Is.EqualTo(1));
+//            Assert.That(errors[0].ErrorType,
+//                Is.EqualTo(ExpressionChecker.Error.AllItemsSkippable));
 //        Assert.IsInstanceOf<EcError>(errors[0]);
 //        var err = (errors[0] as EcError);
-//            Assert.AreSame(expr, err.Expression);
-//            Assert.AreSame(null, err.ExpressionItem);
-//            Assert.AreSame(defs[0], err.DefinitionInfo);
+//            Assert.That(err.Expression, Is.SameAs(expr));
+//            Assert.That(err.ExpressionItem, Is.SameAs(null));
+//            Assert.That(err.DefinitionInfo, Is.SameAs(defs[0]));
 
 
         [Test()]
@@ -612,13 +632,14 @@ namespace MetaphysicsIndustries.Giza.Test
             List<Error> errors = ec.CheckDefinitions(defs);
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual(ExpressionError.DefRefNameNotFound, errors[0].ErrorType);
+            Assert.That(errors.Count, Is.EqualTo(1));
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(ExpressionError.DefRefNameNotFound));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var err = (errors[0] as ExpressionError);
-            Assert.AreSame(null, err.Expression);
-            Assert.AreSame(defref, err.ExpressionItem);
-            Assert.AreSame(defs[0], err.Definition);
+            Assert.That(err.Expression, Is.SameAs(null));
+            Assert.That(err.ExpressionItem, Is.SameAs(defref));
+            Assert.That(err.Definition, Is.SameAs(defs[0]));
         }
 
         [Test()]
@@ -641,12 +662,13 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             ExpressionError e = (ExpressionError)errors[0];
-            Assert.AreEqual(ExpressionError.ReusedDefintion, e.ErrorType);
-            Assert.AreSame(def, e.Definition);
-            Assert.AreEqual(1, e.Index);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ExpressionError.ReusedDefintion));
+            Assert.That(e.Definition, Is.SameAs(def));
+            Assert.That(e.Index, Is.EqualTo(1));
         }
 
         [Test()]
@@ -667,12 +689,13 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ExpressionError>(errors[0]);
             var e = (ExpressionError)errors[0];
-            Assert.AreEqual(ExpressionError.NullDefinition, e.ErrorType);
-            Assert.AreSame(null, e.Definition);
-            Assert.AreEqual(1, e.Index);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ExpressionError.NullDefinition));
+            Assert.That(e.Definition, Is.SameAs(null));
+            Assert.That(e.Index, Is.EqualTo(1));
         }
 
     }

--- a/MetaphysicsIndustries.Giza.Test/GrammarCompilerT/GetNodesFromExpressionTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/GrammarCompilerT/GetNodesFromExpressionTest.cs
@@ -36,9 +36,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             var result = gc.GetNodesFromExpression(expr, null);
             // then
             Assert.IsFalse(result.IsSkippable);
-            Assert.AreEqual(1, result.Nodes.Count);
-            Assert.AreEqual(1, result.StartNodes.Count);
-            Assert.AreEqual(1, result.EndNodes.Count);
+            Assert.That(result.Nodes.Count, Is.EqualTo(1));
+            Assert.That(result.StartNodes.Count, Is.EqualTo(1));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(1));
             var node = result.Nodes[0];
             Assert.Contains(node, result.StartNodes.ToList());
             Assert.Contains(node, result.EndNodes.ToList());
@@ -58,14 +58,14 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             var result = gc.GetNodesFromExpression(expr, null);
             // then
             Assert.IsFalse(result.IsSkippable);
-            Assert.AreEqual(2, result.Nodes.Count);
-            Assert.AreEqual(1, result.StartNodes.Count);
-            Assert.AreEqual(1, result.EndNodes.Count);
+            Assert.That(result.Nodes.Count, Is.EqualTo(2));
+            Assert.That(result.StartNodes.Count, Is.EqualTo(1));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(1));
             var node0 = result.Nodes[0];
             var node1 = result.Nodes[1];
             Assert.Contains(node0, result.StartNodes.ToList());
             Assert.Contains(node1, result.EndNodes.ToList());
-            Assert.AreEqual(1, node0.NextNodes.Count);
+            Assert.That(node0.NextNodes.Count, Is.EqualTo(1));
             Assert.Contains(node1, node0.NextNodes.ToList());
             Assert.IsEmpty(node1.NextNodes);
             Assert.IsFalse(result.IsSkippable);
@@ -83,9 +83,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             var result = gc.GetNodesFromExpression(expr, null);
             // then
             Assert.IsFalse(result.IsSkippable);
-            Assert.AreEqual(2,result.Nodes.Count);
-            Assert.AreEqual(2,result.StartNodes.Count);
-            Assert.AreEqual(1,result.EndNodes.Count);
+            Assert.That(result.Nodes.Count, Is.EqualTo(2));
+            Assert.That(result.StartNodes.Count, Is.EqualTo(2));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(1));
             var node0 = result.Nodes[0];
             Assert.Contains(node0, result.StartNodes.ToList());
             Assert.IsFalse(result.EndNodes.Contains(node0));
@@ -107,9 +107,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             var result = gc.GetNodesFromExpression(expr, null);
             // then
             Assert.IsFalse(result.IsSkippable);
-            Assert.AreEqual(2,result.Nodes.Count);
-            Assert.AreEqual(1,result.StartNodes.Count);
-            Assert.AreEqual(2,result.EndNodes.Count);
+            Assert.That(result.Nodes.Count, Is.EqualTo(2));
+            Assert.That(result.StartNodes.Count, Is.EqualTo(1));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(2));
             var node0 = result.Nodes[0];
             Assert.Contains(node0, result.StartNodes.ToList());
             Assert.Contains(node0, result.EndNodes.ToList());
@@ -134,9 +134,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             var result = gc.GetNodesFromExpression(expr, null);
             // then
             Assert.IsFalse(result.IsSkippable);
-            Assert.AreEqual(5,result.Nodes.Count);
-            Assert.AreEqual(1,result.StartNodes.Count);
-            Assert.AreEqual(1,result.EndNodes.Count);
+            Assert.That(result.Nodes.Count, Is.EqualTo(5));
+            Assert.That(result.StartNodes.Count, Is.EqualTo(1));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(1));
 
             var node0 = result.Nodes[0];
             var node1 = result.Nodes[1];
@@ -146,29 +146,29 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
 
             Assert.IsTrue(result.StartNodes.Contains(node0));
             Assert.IsFalse(result.EndNodes.Contains(node0));
-            Assert.AreEqual(2, node0.NextNodes.Count);
+            Assert.That(node0.NextNodes.Count, Is.EqualTo(2));
             Assert.Contains(node1,node0.NextNodes.ToList());
             Assert.Contains(node2,node0.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node1));
             Assert.IsFalse(result.EndNodes.Contains(node1));
-            Assert.AreEqual(1, node1.NextNodes.Count);
+            Assert.That(node1.NextNodes.Count, Is.EqualTo(1));
             Assert.Contains(node2,node1.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node2));
             Assert.IsFalse(result.EndNodes.Contains(node2));
-            Assert.AreEqual(2, node2.NextNodes.Count);
+            Assert.That(node2.NextNodes.Count, Is.EqualTo(2));
             Assert.Contains(node3,node2.NextNodes.ToList());
             Assert.Contains(node4,node2.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node3));
             Assert.IsFalse(result.EndNodes.Contains(node3));
-            Assert.AreEqual(1, node3.NextNodes.Count);
+            Assert.That(node3.NextNodes.Count, Is.EqualTo(1));
             Assert.Contains(node4,node3.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node4));
             Assert.IsTrue(result.EndNodes.Contains(node4));
-            Assert.AreEqual(0, node4.NextNodes.Count);
+            Assert.That(node4.NextNodes.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -186,9 +186,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             var result = gc.GetNodesFromExpression(expr, null);
             // then
             Assert.IsFalse(result.IsSkippable);
-            Assert.AreEqual(5,result.Nodes.Count);
-            Assert.AreEqual(1,result.StartNodes.Count);
-            Assert.AreEqual(1,result.EndNodes.Count);
+            Assert.That(result.Nodes.Count, Is.EqualTo(5));
+            Assert.That(result.StartNodes.Count, Is.EqualTo(1));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(1));
 
             var node0 = result.Nodes[0];
             var node1 = result.Nodes[1];
@@ -198,7 +198,7 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
 
             Assert.IsTrue(result.StartNodes.Contains(node0));
             Assert.IsFalse(result.EndNodes.Contains(node0));
-            Assert.AreEqual(4, node0.NextNodes.Count);
+            Assert.That(node0.NextNodes.Count, Is.EqualTo(4));
             Assert.Contains(node1,node0.NextNodes.ToList());
             Assert.Contains(node2,node0.NextNodes.ToList());
             Assert.Contains(node3,node0.NextNodes.ToList());
@@ -206,25 +206,25 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
 
             Assert.IsFalse(result.StartNodes.Contains(node1));
             Assert.IsFalse(result.EndNodes.Contains(node1));
-            Assert.AreEqual(3, node1.NextNodes.Count);
+            Assert.That(node1.NextNodes.Count, Is.EqualTo(3));
             Assert.Contains(node2,node1.NextNodes.ToList());
             Assert.Contains(node3,node1.NextNodes.ToList());
             Assert.Contains(node4,node1.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node2));
             Assert.IsFalse(result.EndNodes.Contains(node2));
-            Assert.AreEqual(2, node2.NextNodes.Count);
+            Assert.That(node2.NextNodes.Count, Is.EqualTo(2));
             Assert.Contains(node3,node2.NextNodes.ToList());
             Assert.Contains(node4,node2.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node3));
             Assert.IsFalse(result.EndNodes.Contains(node3));
-            Assert.AreEqual(1, node3.NextNodes.Count);
+            Assert.That(node3.NextNodes.Count, Is.EqualTo(1));
             Assert.Contains(node4,node3.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node4));
             Assert.IsTrue(result.EndNodes.Contains(node4));
-            Assert.AreEqual(0, node4.NextNodes.Count);
+            Assert.That(node4.NextNodes.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -242,9 +242,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             var result = gc.GetNodesFromExpression(expr, null);
             // then
             Assert.IsFalse(result.IsSkippable);
-            Assert.AreEqual(5,result.Nodes.Count);
-            Assert.AreEqual(1,result.StartNodes.Count);
-            Assert.AreEqual(1,result.EndNodes.Count);
+            Assert.That(result.Nodes.Count, Is.EqualTo(5));
+            Assert.That(result.StartNodes.Count, Is.EqualTo(1));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(1));
 
             var node0 = result.Nodes[0];
             var node1 = result.Nodes[1];
@@ -254,30 +254,30 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
 
             Assert.IsTrue(result.StartNodes.Contains(node0));
             Assert.IsFalse(result.EndNodes.Contains(node0));
-            Assert.AreEqual(3, node0.NextNodes.Count);
+            Assert.That(node0.NextNodes.Count, Is.EqualTo(3));
             Assert.Contains(node1,node0.NextNodes.ToList());
             Assert.Contains(node2,node0.NextNodes.ToList());
             Assert.Contains(node3,node0.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node1));
             Assert.IsFalse(result.EndNodes.Contains(node1));
-            Assert.AreEqual(2, node1.NextNodes.Count);
+            Assert.That(node1.NextNodes.Count, Is.EqualTo(2));
             Assert.Contains(node2,node1.NextNodes.ToList());
             Assert.Contains(node3,node1.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node2));
             Assert.IsFalse(result.EndNodes.Contains(node2));
-            Assert.AreEqual(1, node2.NextNodes.Count);
+            Assert.That(node2.NextNodes.Count, Is.EqualTo(1));
             Assert.Contains(node3,node2.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node3));
             Assert.IsFalse(result.EndNodes.Contains(node3));
-            Assert.AreEqual(1, node3.NextNodes.Count);
+            Assert.That(node3.NextNodes.Count, Is.EqualTo(1));
             Assert.Contains(node4,node3.NextNodes.ToList());
 
             Assert.IsFalse(result.StartNodes.Contains(node4));
             Assert.IsTrue(result.EndNodes.Contains(node4));
-            Assert.AreEqual(0, node4.NextNodes.Count);
+            Assert.That(node4.NextNodes.Count, Is.EqualTo(0));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/GrammarCompilerT/GetNodesFromOrExpressionTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/GrammarCompilerT/GetNodesFromOrExpressionTest.cs
@@ -1,4 +1,3 @@
-
 // MetaphysicsIndustries.Giza - A Parsing System
 // Copyright (C) 2008-2021 Metaphysics Industries, Inc.
 //
@@ -42,9 +41,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             // when
             var result = gc.GetNodesFromOrExpression(orexpr, null);
             // then
-            Assert.AreEqual(1,result.StartNodes.Count);
-            Assert.AreEqual(1,result.EndNodes.Count);
-            Assert.AreEqual(1,result.Nodes.Count);
+            Assert.That(result.StartNodes.Count, Is.EqualTo(1));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(1));
+            Assert.That(result.Nodes.Count, Is.EqualTo(1));
             var node = result.Nodes[0];
             Assert.Contains(node, result.StartNodes.ToList());
             Assert.Contains(node, result.EndNodes.ToList());
@@ -70,9 +69,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             // when
             var result = gc.GetNodesFromOrExpression(orexpr, null);
             // then
-            Assert.AreEqual(2,result.StartNodes.Count);
-            Assert.AreEqual(2,result.EndNodes.Count);
-            Assert.AreEqual(2,result.Nodes.Count);
+            Assert.That(result.StartNodes.Count, Is.EqualTo(2));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(2));
+            Assert.That(result.Nodes.Count, Is.EqualTo(2));
             var node0 = result.Nodes[0];
             Assert.Contains(node0, result.StartNodes.ToList());
             Assert.Contains(node0, result.EndNodes.ToList());
@@ -100,9 +99,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             // when
             var result = gc.GetNodesFromOrExpression(orexpr, null);
             // then
-            Assert.AreEqual(1,result.StartNodes.Count);
-            Assert.AreEqual(1,result.EndNodes.Count);
-            Assert.AreEqual(2,result.Nodes.Count);
+            Assert.That(result.StartNodes.Count, Is.EqualTo(1));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(1));
+            Assert.That(result.Nodes.Count, Is.EqualTo(2));
             var node0 = result.Nodes[0];
             Assert.Contains(node0, result.StartNodes.ToList());
             Assert.IsFalse(result.EndNodes.Contains(node0));
@@ -130,9 +129,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             // when
             var result = gc.GetNodesFromOrExpression(orexpr, null);
             // then
-            Assert.AreEqual(2,result.StartNodes.Count);
-            Assert.AreEqual(1,result.EndNodes.Count);
-            Assert.AreEqual(2,result.Nodes.Count);
+            Assert.That(result.StartNodes.Count, Is.EqualTo(2));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(1));
+            Assert.That(result.Nodes.Count, Is.EqualTo(2));
             var node0 = result.Nodes[0];
             Assert.Contains(node0, result.StartNodes.ToList());
             Assert.IsFalse(result.EndNodes.Contains(node0));
@@ -161,9 +160,9 @@ namespace MetaphysicsIndustries.Giza.Test.GrammarCompilerT
             // when
             var result = gc.GetNodesFromOrExpression(orexpr, null);
             // then
-            Assert.AreEqual(1,result.StartNodes.Count);
-            Assert.AreEqual(2,result.EndNodes.Count);
-            Assert.AreEqual(2,result.Nodes.Count);
+            Assert.That(result.StartNodes.Count, Is.EqualTo(1));
+            Assert.That(result.EndNodes.Count, Is.EqualTo(2));
+            Assert.That(result.Nodes.Count, Is.EqualTo(2));
             var node0 = result.Nodes[0];
             Assert.Contains(node0, result.StartNodes.ToList());
             Assert.Contains(node0, result.EndNodes.ToList());

--- a/MetaphysicsIndustries.Giza.Test/ImportTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/ImportTest.cs
@@ -35,12 +35,12 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = ss.GetGrammar(src, errors);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Definitions.Count);
-            Assert.AreEqual(1, result.ImportStatements.Count);
-            Assert.AreEqual("file1.txt",
-                result.ImportStatements[0].Filename);
+            Assert.That(result.Definitions.Count, Is.EqualTo(0));
+            Assert.That(result.ImportStatements.Count, Is.EqualTo(1));
+            Assert.That(result.ImportStatements[0].Filename,
+                Is.EqualTo("file1.txt"));
             Assert.IsNull(result.ImportStatements[0].ImportRefs);
             Assert.IsTrue(result.ImportStatements[0].ImportAll);
         }
@@ -55,17 +55,18 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = ss.GetGrammar(src, errors);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Definitions.Count);
-            Assert.AreEqual(1, result.ImportStatements.Count);
-            Assert.AreEqual("file1.txt",
-                result.ImportStatements[0].Filename);
+            Assert.That(result.Definitions.Count, Is.EqualTo(0));
+            Assert.That(result.ImportStatements.Count, Is.EqualTo(1));
+            Assert.That(result.ImportStatements[0].Filename,
+                Is.EqualTo("file1.txt"));
             Assert.IsNotNull(result.ImportStatements[0].ImportRefs);
-            Assert.AreEqual(1, result.ImportStatements[0].ImportRefs.Length);
+            Assert.That(result.ImportStatements[0].ImportRefs.Length,
+                Is.EqualTo(1));
             var importRef = result.ImportStatements[0].ImportRefs[0];
-            Assert.AreEqual("def1", importRef.SourceName);
-            Assert.AreEqual("def1", importRef.DestName);
+            Assert.That(importRef.SourceName, Is.EqualTo("def1"));
+            Assert.That(importRef.DestName, Is.EqualTo("def1"));
             Assert.IsFalse(result.ImportStatements[0].ImportAll);
         }
 
@@ -79,20 +80,21 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = ss.GetGrammar(src, errors);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Definitions.Count);
-            Assert.AreEqual(1, result.ImportStatements.Count);
-            Assert.AreEqual("file1.txt",
-                result.ImportStatements[0].Filename);
+            Assert.That(result.Definitions.Count, Is.EqualTo(0));
+            Assert.That(result.ImportStatements.Count, Is.EqualTo(1));
+            Assert.That(result.ImportStatements[0].Filename,
+                Is.EqualTo("file1.txt"));
             Assert.IsNotNull(result.ImportStatements[0].ImportRefs);
-            Assert.AreEqual(2, result.ImportStatements[0].ImportRefs.Length);
+            Assert.That(result.ImportStatements[0].ImportRefs.Length,
+                Is.EqualTo(2));
             var importRef1 = result.ImportStatements[0].ImportRefs[0];
-            Assert.AreEqual("def1", importRef1.SourceName);
-            Assert.AreEqual("def1", importRef1.DestName);
+            Assert.That(importRef1.SourceName, Is.EqualTo("def1"));
+            Assert.That(importRef1.DestName, Is.EqualTo("def1"));
             var importRef2 = result.ImportStatements[0].ImportRefs[1];
-            Assert.AreEqual("def3", importRef2.SourceName);
-            Assert.AreEqual("def3", importRef2.DestName);
+            Assert.That(importRef2.SourceName, Is.EqualTo("def3"));
+            Assert.That(importRef2.DestName, Is.EqualTo("def3"));
             Assert.IsFalse(result.ImportStatements[0].ImportAll);
         }
 
@@ -107,27 +109,27 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = ss.GetGrammar(src, errors);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Definitions.Count);
-            Assert.AreEqual(2, result.ImportStatements.Count);
+            Assert.That(result.Definitions.Count, Is.EqualTo(0));
+            Assert.That(result.ImportStatements.Count, Is.EqualTo(2));
             var importStmt1 = result.ImportStatements[0];
-            Assert.AreEqual("file1.txt", importStmt1.Filename);
+            Assert.That(importStmt1.Filename, Is.EqualTo("file1.txt"));
             Assert.IsFalse(importStmt1.ImportAll);
             Assert.IsNotNull(importStmt1.ImportRefs);
-            Assert.AreEqual(1, importStmt1.ImportRefs.Length);
+            Assert.That(importStmt1.ImportRefs.Length, Is.EqualTo(1));
             var importRef1 = importStmt1.ImportRefs[0];
-            Assert.AreEqual("def1", importRef1.SourceName);
-            Assert.AreEqual("def1", importRef1.DestName);
+            Assert.That(importRef1.SourceName, Is.EqualTo("def1"));
+            Assert.That(importRef1.DestName, Is.EqualTo("def1"));
 
             var importStmt2 = result.ImportStatements[0];
-            Assert.AreEqual("file1.txt", importStmt2.Filename);
+            Assert.That(importStmt2.Filename, Is.EqualTo("file1.txt"));
             Assert.IsFalse(importStmt2.ImportAll);
             Assert.IsNotNull(importStmt2.ImportRefs);
-            Assert.AreEqual(1, importStmt2.ImportRefs.Length);
+            Assert.That(importStmt2.ImportRefs.Length, Is.EqualTo(1));
             var importRef2 = importStmt2.ImportRefs[0];
-            Assert.AreEqual("def1", importRef2.SourceName);
-            Assert.AreEqual("def1", importRef2.DestName);
+            Assert.That(importRef2.SourceName, Is.EqualTo("def1"));
+            Assert.That(importRef2.DestName, Is.EqualTo("def1"));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/ImportTransformTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/ImportTransformTest.cs
@@ -48,9 +48,9 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = importer.Transform(g, errors, mfs);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Definitions.Count);
+            Assert.That(result.Definitions.Count, Is.EqualTo(2));
             Assert.That(result.Definitions[0].Name == "def1" ||
                         result.Definitions[1].Name == "def1");
             Assert.That(result.Definitions[0].Name == "def2" ||
@@ -88,9 +88,9 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = importer.Transform(g, errors, mfs);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Definitions.Count);
+            Assert.That(result.Definitions.Count, Is.EqualTo(1));
             Assert.That(result.Definitions[0].Name == "def1");
             Assert.IsTrue(result.Definitions[0].IsImported);
         }
@@ -130,9 +130,9 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = importer.Transform(g, errors, mfs);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Definitions.Count);
+            Assert.That(result.Definitions.Count, Is.EqualTo(2));
             Assert.That(result.Definitions[0].Name == "def1" ||
                         result.Definitions[1].Name == "def1");
             Assert.That(result.Definitions[0].Name == "def3" ||
@@ -169,17 +169,17 @@ namespace MetaphysicsIndustries.Giza.Test
             var result1 = importer.Transform(g, errors1, mfs);
             var result2 = importer.Transform(g, errors2, mfs);
             // then
-            Assert.AreEqual(0, errors1.Count);
+            Assert.That(errors1.Count, Is.EqualTo(0));
             Assert.IsNotNull(result1);
-            Assert.AreEqual(1, result1.Definitions.Count);
+            Assert.That(result1.Definitions.Count, Is.EqualTo(1));
             Assert.That(result1.Definitions[0].Name == "def1");
             // and
-            Assert.AreEqual(0, errors2.Count);
+            Assert.That(errors2.Count, Is.EqualTo(0));
             Assert.IsNotNull(result2);
-            Assert.AreEqual(1, result2.Definitions.Count);
+            Assert.That(result2.Definitions.Count, Is.EqualTo(1));
             Assert.That(result2.Definitions[0].Name == "def1");
             // and
-            Assert.AreEqual(1, callCount);
+            Assert.That(callCount, Is.EqualTo(1));
         }
 
         [Test]
@@ -226,9 +226,9 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = importer.Transform(g, errors, mfs);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(4, result.Definitions.Count);
+            Assert.That(result.Definitions.Count, Is.EqualTo(4));
             Assert.That(result.Definitions[0].Name == "def1" ||
                         result.Definitions[0].Name == "def2" ||
                         result.Definitions[0].Name == "def3" ||
@@ -283,14 +283,14 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = importer.Transform(g, errors, mfs);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Definitions.Count);
-            Assert.AreEqual("def1", result.Definitions[0].Name);
-            Assert.AreEqual(1, result.Definitions[0].Expr.Items.Count);
+            Assert.That(result.Definitions.Count, Is.EqualTo(1));
+            Assert.That(result.Definitions[0].Name, Is.EqualTo("def1"));
+            Assert.That(result.Definitions[0].Expr.Items.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<LiteralSubExpression>(result.Definitions[0].Expr.Items[0]);
             var literal = (LiteralSubExpression) result.Definitions[0].Expr.Items[0];
-            Assert.AreEqual("b", literal.Value);
+            Assert.That(literal.Value, Is.EqualTo("b"));
         }
 
         [Test]
@@ -342,9 +342,9 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = importer.Transform(g, errors, mfs);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Definitions.Count);
+            Assert.That(result.Definitions.Count, Is.EqualTo(2));
 
             Assert.That(result.Definitions[0].Name == "def1" ||
                         result.Definitions[0].Name == "def2");
@@ -355,15 +355,15 @@ namespace MetaphysicsIndustries.Giza.Test
             var def2 = (result.Definitions[0].Name == "def2" ?
                 result.Definitions[0] : result.Definitions[1]);
 
-            Assert.AreEqual(1, def1.Expr.Items.Count);
+            Assert.That(def1.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<LiteralSubExpression>(def1.Expr.Items[0]);
             var literal1 = (LiteralSubExpression) def1.Expr.Items[0];
-            Assert.AreEqual("a", literal1.Value);
+            Assert.That(literal1.Value, Is.EqualTo("a"));
 
-            Assert.AreEqual(1, def2.Expr.Items.Count);
+            Assert.That(def2.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<LiteralSubExpression>(def2.Expr.Items[0]);
             var literal2 = (LiteralSubExpression) def2.Expr.Items[0];
-            Assert.AreEqual("b", literal2.Value);
+            Assert.That(literal2.Value, Is.EqualTo("b"));
         }
 
         [Test]
@@ -389,13 +389,13 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = importer.Transform(g, errors, mfs);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual("src1", result.Source);
-            Assert.AreEqual(1, result.Definitions.Count);
-            Assert.AreEqual("def1", result.Definitions[0].Name);
+            Assert.That(result.Source, Is.EqualTo("src1"));
+            Assert.That(result.Definitions.Count, Is.EqualTo(1));
+            Assert.That(result.Definitions[0].Name, Is.EqualTo("def1"));
             Assert.IsTrue(result.Definitions[0].IsImported);
-            Assert.AreEqual("file1.txt", result.Definitions[0].Source);
+            Assert.That(result.Definitions[0].Source, Is.EqualTo("file1.txt"));
         }
 
         [Test]
@@ -429,14 +429,14 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = importer.Transform(g, errors, mfs);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual("/base/path1/file1.giza", result.Source);
-            Assert.AreEqual(1, result.Definitions.Count);
+            Assert.That(result.Source, Is.EqualTo("/base/path1/file1.giza"));
+            Assert.That(result.Definitions.Count, Is.EqualTo(1));
             Assert.That(result.Definitions[0].Name == "def1");
             Assert.IsTrue(result.Definitions[0].IsImported);
-            Assert.AreEqual("/base/path2/file2.giza",
-                result.Definitions[0].Source);
+            Assert.That(result.Definitions[0].Source,
+                Is.EqualTo("/base/path2/file2.giza"));
         }
 
         [Test]
@@ -462,11 +462,11 @@ namespace MetaphysicsIndustries.Giza.Test
             // when
             var result = importer.Transform(g, errors, mfs);
             // then
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.Definitions.Count);
-            Assert.AreEqual(0, result.ImportStatements.Count);
-            Assert.AreEqual("src", result.Source);
+            Assert.That(result.Definitions.Count, Is.EqualTo(0));
+            Assert.That(result.ImportStatements.Count, Is.EqualTo(0));
+            Assert.That(result.Source, Is.EqualTo("src"));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/NodeMatchTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/NodeMatchTest.cs
@@ -34,11 +34,11 @@ namespace MetaphysicsIndustries.Giza.Test
 
             var clone = nm.CloneWithNewInputElement(new Token(startPosition: new InputPosition(5), value: "zxcv"));
 
-            Assert.AreSame(node, clone.Node);
-            Assert.AreEqual(TransitionType.Follow, clone.Transition);
-            Assert.AreEqual(5, clone.StartPosition.Index);
-            Assert.AreEqual(5, clone.InputElement.StartPosition.Index);
-            Assert.AreEqual("zxcv", clone.InputElement.Value);
+            Assert.That(clone.Node, Is.SameAs(node));
+            Assert.That(clone.Transition, Is.EqualTo(TransitionType.Follow));
+            Assert.That(clone.StartPosition.Index, Is.EqualTo(5));
+            Assert.That(clone.InputElement.StartPosition.Index, Is.EqualTo(5));
+            Assert.That(clone.InputElement.Value, Is.EqualTo("zxcv"));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/ParserTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/ParserTest.cs
@@ -87,20 +87,20 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(s);
-            Assert.AreEqual(1, s.Length);
-            Assert.AreEqual(3, s[0].Subspans.Count);
+            Assert.That(s.Length, Is.EqualTo(1));
+            Assert.That(s[0].Subspans.Count, Is.EqualTo(3));
 
-            Assert.AreSame(exprDef.Nodes[0], s[0].Subspans[0].Node);
-            Assert.AreSame(operandDef, s[0].Subspans[0].DefRef);
-            Assert.AreEqual("a", s[0].Subspans[0].Value);
+            Assert.That(s[0].Subspans[0].Node, Is.SameAs(exprDef.Nodes[0]));
+            Assert.That(s[0].Subspans[0].DefRef, Is.SameAs(operandDef));
+            Assert.That(s[0].Subspans[0].Value, Is.EqualTo("a"));
 
-            Assert.AreSame(exprDef.Nodes[1], s[0].Subspans[1].Node);
-            Assert.AreSame(operatorDef, s[0].Subspans[1].DefRef);
-            Assert.AreEqual("+", s[0].Subspans[1].Value);
+            Assert.That(s[0].Subspans[1].Node, Is.SameAs(exprDef.Nodes[1]));
+            Assert.That(s[0].Subspans[1].DefRef, Is.SameAs(operatorDef));
+            Assert.That(s[0].Subspans[1].Value, Is.EqualTo("+"));
 
-            Assert.AreSame(exprDef.Nodes[2], s[0].Subspans[2].Node);
-            Assert.AreSame(operandDef, s[0].Subspans[2].DefRef);
-            Assert.AreEqual("b", s[0].Subspans[2].Value);
+            Assert.That(s[0].Subspans[2].Node, Is.SameAs(exprDef.Nodes[2]));
+            Assert.That(s[0].Subspans[2].DefRef, Is.SameAs(operandDef));
+            Assert.That(s[0].Subspans[2].Value, Is.EqualTo("b"));
         }
 
         [Test]
@@ -135,19 +135,19 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(s);
-            Assert.AreEqual(2, s.Length);
+            Assert.That(s.Length, Is.EqualTo(2));
 
-            Assert.AreEqual(3, s[0].Subspans.Count);
-            Assert.AreSame(subexprDef, s[0].Subspans[0].DefRef);
-            Assert.AreSame(plusDef, s[0].Subspans[1].DefRef);
-            Assert.AreEqual(0, s[0].Subspans[1].Subspans.Count);
-            Assert.AreSame(subexprDef, s[0].Subspans[2].DefRef);
+            Assert.That(s[0].Subspans.Count, Is.EqualTo(3));
+            Assert.That(s[0].Subspans[0].DefRef, Is.SameAs(subexprDef));
+            Assert.That(s[0].Subspans[1].DefRef, Is.SameAs(plusDef));
+            Assert.That(s[0].Subspans[1].Subspans.Count, Is.EqualTo(0));
+            Assert.That(s[0].Subspans[2].DefRef, Is.SameAs(subexprDef));
 
-            Assert.AreEqual(3, s[1].Subspans.Count);
-            Assert.AreSame(subexprDef, s[1].Subspans[0].DefRef);
-            Assert.AreSame(plusDef, s[1].Subspans[1].DefRef);
-            Assert.AreEqual(0, s[1].Subspans[1].Subspans.Count);
-            Assert.AreSame(subexprDef, s[1].Subspans[2].DefRef);
+            Assert.That(s[1].Subspans.Count, Is.EqualTo(3));
+            Assert.That(s[1].Subspans[0].DefRef, Is.SameAs(subexprDef));
+            Assert.That(s[1].Subspans[1].DefRef, Is.SameAs(plusDef));
+            Assert.That(s[1].Subspans[1].Subspans.Count, Is.EqualTo(0));
+            Assert.That(s[1].Subspans[2].DefRef, Is.SameAs(subexprDef));
 
             Assert.True(s[0].Subspans[0].Subspans.Count == 1 ||
                         s[0].Subspans[0].Subspans.Count == 2);
@@ -168,27 +168,43 @@ namespace MetaphysicsIndustries.Giza.Test
                 twoOne = s[0];
             }
 
-            Assert.AreEqual(1, oneTwo.Subspans[0].Subspans.Count);
-            Assert.AreEqual(0, oneTwo.Subspans[0].Subspans[0].Subspans.Count);
-            Assert.AreSame(operandDef, oneTwo.Subspans[0].Subspans[0].DefRef);
-            Assert.AreEqual("a", oneTwo.Subspans[0].Subspans[0].Value);
-            Assert.AreEqual(2, oneTwo.Subspans[2].Subspans.Count);
-            Assert.AreEqual(0, oneTwo.Subspans[2].Subspans[0].Subspans.Count);
-            Assert.AreSame(plusPlusDef, oneTwo.Subspans[2].Subspans[0].DefRef);
-            Assert.AreEqual(0, oneTwo.Subspans[2].Subspans[1].Subspans.Count);
-            Assert.AreSame(operandDef, oneTwo.Subspans[2].Subspans[1].DefRef);
-            Assert.AreEqual("b", oneTwo.Subspans[2].Subspans[1].Value);
+            Assert.That(oneTwo.Subspans[0].Subspans.Count, Is.EqualTo(1));
+            Assert.That(oneTwo.Subspans[0].Subspans[0].Subspans.Count,
+                Is.EqualTo(0));
+            Assert.That(oneTwo.Subspans[0].Subspans[0].DefRef,
+                Is.SameAs(operandDef));
+            Assert.That(oneTwo.Subspans[0].Subspans[0].Value,
+                Is.EqualTo("a"));
+            Assert.That(oneTwo.Subspans[2].Subspans.Count, Is.EqualTo(2));
+            Assert.That(oneTwo.Subspans[2].Subspans[0].Subspans.Count,
+                Is.EqualTo(0));
+            Assert.That(oneTwo.Subspans[2].Subspans[0].DefRef,
+                Is.SameAs(plusPlusDef));
+            Assert.That(oneTwo.Subspans[2].Subspans[1].Subspans.Count,
+                Is.EqualTo(0));
+            Assert.That(oneTwo.Subspans[2].Subspans[1].DefRef,
+                Is.SameAs(operandDef));
+            Assert.That(oneTwo.Subspans[2].Subspans[1].Value,
+                Is.EqualTo("b"));
 
-            Assert.AreEqual(2, twoOne.Subspans[0].Subspans.Count);
-            Assert.AreEqual(0, twoOne.Subspans[0].Subspans[0].Subspans.Count);
-            Assert.AreSame(operandDef, twoOne.Subspans[0].Subspans[0].DefRef);
-            Assert.AreEqual("a", twoOne.Subspans[0].Subspans[0].Value);
-            Assert.AreSame(plusPlusDef, twoOne.Subspans[0].Subspans[1].DefRef);
-            Assert.AreEqual(0, twoOne.Subspans[0].Subspans[1].Subspans.Count);
-            Assert.AreEqual(1, twoOne.Subspans[2].Subspans.Count);
-            Assert.AreEqual(0, twoOne.Subspans[2].Subspans[0].Subspans.Count);
-            Assert.AreSame(operandDef, twoOne.Subspans[2].Subspans[0].DefRef);
-            Assert.AreEqual("b", twoOne.Subspans[2].Subspans[0].Value);
+            Assert.That(twoOne.Subspans[0].Subspans.Count, Is.EqualTo(2));
+            Assert.That(twoOne.Subspans[0].Subspans[0].Subspans.Count,
+                Is.EqualTo(0));
+            Assert.That(twoOne.Subspans[0].Subspans[0].DefRef,
+                Is.SameAs(operandDef));
+            Assert.That(twoOne.Subspans[0].Subspans[0].Value,
+                Is.EqualTo("a"));
+            Assert.That(twoOne.Subspans[0].Subspans[1].DefRef,
+                Is.SameAs(plusPlusDef));
+            Assert.That(twoOne.Subspans[0].Subspans[1].Subspans.Count,
+                Is.EqualTo(0));
+            Assert.That(twoOne.Subspans[2].Subspans.Count, Is.EqualTo(1));
+            Assert.That(twoOne.Subspans[2].Subspans[0].Subspans.Count,
+                Is.EqualTo(0));
+            Assert.That(twoOne.Subspans[2].Subspans[0].DefRef,
+                Is.SameAs(operandDef));
+            Assert.That(twoOne.Subspans[2].Subspans[0].Value,
+                Is.EqualTo("b"));
         }
 
         [Test]
@@ -237,23 +253,23 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(3, spans[0].Subspans.Count);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(3));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[0].DefRef);
-            Assert.AreEqual("item", spans[0].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[0].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[0].Value, Is.EqualTo("item"));
+            Assert.That(spans[0].Subspans[0].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[1].DefRef);
-            Assert.AreEqual("ITEM", spans[0].Subspans[1].Value);
-            Assert.AreEqual(0, spans[0].Subspans[1].Subspans.Count);
+            Assert.That(spans[0].Subspans[1].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[1].Value, Is.EqualTo("ITEM"));
+            Assert.That(spans[0].Subspans[1].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[2].DefRef);
-            Assert.AreEqual("iTeM", spans[0].Subspans[2].Value);
-            Assert.AreEqual(0, spans[0].Subspans[2].Subspans.Count);
+            Assert.That(spans[0].Subspans[2].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[2].Value, Is.EqualTo("iTeM"));
+            Assert.That(spans[0].Subspans[2].Subspans.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -300,23 +316,23 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(3, spans[0].Subspans.Count);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(3));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[0].DefRef);
-            Assert.AreEqual("item", spans[0].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[0].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[0].Value, Is.EqualTo("item"));
+            Assert.That(spans[0].Subspans[0].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[1].DefRef);
-            Assert.AreEqual("ITEM", spans[0].Subspans[1].Value);
-            Assert.AreEqual(0, spans[0].Subspans[1].Subspans.Count);
+            Assert.That(spans[0].Subspans[1].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[1].Value, Is.EqualTo("ITEM"));
+            Assert.That(spans[0].Subspans[1].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[2].DefRef);
-            Assert.AreEqual("iTeM", spans[0].Subspans[2].Value);
-            Assert.AreEqual(0, spans[0].Subspans[2].Subspans.Count);
+            Assert.That(spans[0].Subspans[2].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[2].Value, Is.EqualTo("iTeM"));
+            Assert.That(spans[0].Subspans[2].Subspans.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -387,23 +403,23 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(3, spans[0].Subspans.Count);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(3));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[0].DefRef);
-            Assert.AreEqual("abcqwerxyz", spans[0].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[0].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[0].Value, Is.EqualTo("abcqwerxyz"));
+            Assert.That(spans[0].Subspans[0].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[1].DefRef);
-            Assert.AreEqual("abcQWERxyz", spans[0].Subspans[1].Value);
-            Assert.AreEqual(0, spans[0].Subspans[1].Subspans.Count);
+            Assert.That(spans[0].Subspans[1].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[1].Value, Is.EqualTo("abcQWERxyz"));
+            Assert.That(spans[0].Subspans[1].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[2].DefRef);
-            Assert.AreEqual("abcQwErxyz", spans[0].Subspans[2].Value);
-            Assert.AreEqual(0, spans[0].Subspans[2].Subspans.Count);
+            Assert.That(spans[0].Subspans[2].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[2].Value, Is.EqualTo("abcQwErxyz"));
+            Assert.That(spans[0].Subspans[2].Subspans.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -471,23 +487,23 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(3, spans[0].Subspans.Count);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(3));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[0].DefRef);
-            Assert.AreEqual("abcqwerxyz", spans[0].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[0].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[0].Value, Is.EqualTo("abcqwerxyz"));
+            Assert.That(spans[0].Subspans[0].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[1].DefRef);
-            Assert.AreEqual("abcQWERxyz", spans[0].Subspans[1].Value);
-            Assert.AreEqual(0, spans[0].Subspans[1].Subspans.Count);
+            Assert.That(spans[0].Subspans[1].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[1].Value, Is.EqualTo("abcQWERxyz"));
+            Assert.That(spans[0].Subspans[1].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[2].DefRef);
-            Assert.AreEqual("abcQwErxyz", spans[0].Subspans[2].Value);
-            Assert.AreEqual(0, spans[0].Subspans[2].Subspans.Count);
+            Assert.That(spans[0].Subspans[2].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[2].Value, Is.EqualTo("abcQwErxyz"));
+            Assert.That(spans[0].Subspans[2].Subspans.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -568,15 +584,16 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(1, spans[0].Subspans.Count);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(1));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[0].DefRef);
-            Assert.AreEqual("abc-qwer-xyz", spans[0].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[0].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[0].Value,
+                Is.EqualTo("abc-qwer-xyz"));
+            Assert.That(spans[0].Subspans[0].Subspans.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -657,14 +674,14 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(1, spans[0].Subspans.Count);
-            Assert.AreSame(itemDef, spans[0].Subspans[0].DefRef);
-            Assert.AreEqual("abc-qw-xyz", spans[0].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[0].Subspans.Count);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(1));
+            Assert.That(spans[0].Subspans[0].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[0].Value, Is.EqualTo("abc-qw-xyz"));
+            Assert.That(spans[0].Subspans[0].Subspans.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -747,23 +764,23 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(3, spans[0].Subspans.Count);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(3));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[0].DefRef);
-            Assert.AreEqual("item", spans[0].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[0].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[0].Value, Is.EqualTo("item"));
+            Assert.That(spans[0].Subspans[0].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[1].DefRef);
-            Assert.AreEqual("item", spans[0].Subspans[1].Value);
-            Assert.AreEqual(0, spans[0].Subspans[1].Subspans.Count);
+            Assert.That(spans[0].Subspans[1].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[1].Value, Is.EqualTo("item"));
+            Assert.That(spans[0].Subspans[1].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[2].DefRef);
-            Assert.AreEqual("item", spans[0].Subspans[2].Value);
-            Assert.AreEqual(0, spans[0].Subspans[2].Subspans.Count);
+            Assert.That(spans[0].Subspans[2].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[2].Value, Is.EqualTo("item"));
+            Assert.That(spans[0].Subspans[2].Subspans.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -835,23 +852,23 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(3, spans[0].Subspans.Count);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(3));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[0].DefRef);
-            Assert.AreEqual("item", spans[0].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[0].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[0].Value, Is.EqualTo("item"));
+            Assert.That(spans[0].Subspans[0].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[1].DefRef);
-            Assert.AreEqual("item", spans[0].Subspans[1].Value);
-            Assert.AreEqual(0, spans[0].Subspans[1].Subspans.Count);
+            Assert.That(spans[0].Subspans[1].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[1].Value, Is.EqualTo("item"));
+            Assert.That(spans[0].Subspans[1].Subspans.Count, Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[2].DefRef);
-            Assert.AreEqual("item", spans[0].Subspans[2].Value);
-            Assert.AreEqual(0, spans[0].Subspans[2].Subspans.Count);
+            Assert.That(spans[0].Subspans[2].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[2].Value, Is.EqualTo("item"));
+            Assert.That(spans[0].Subspans[2].Subspans.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -887,29 +904,38 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(3, spans[0].Subspans.Count);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(3));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[0].DefRef);
-            Assert.AreEqual(1, spans[0].Subspans[0].Subspans.Count);
-            Assert.AreSame(implicitDef, spans[0].Subspans[0].Subspans[0].DefRef);
-            Assert.AreEqual("item", spans[0].Subspans[0].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[0].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[0].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[0].Subspans.Count, Is.EqualTo(1));
+            Assert.That(spans[0].Subspans[0].Subspans[0].DefRef,
+                Is.SameAs(implicitDef));
+            Assert.That(spans[0].Subspans[0].Subspans[0].Value,
+                Is.EqualTo("item"));
+            Assert.That(spans[0].Subspans[0].Subspans[0].Subspans.Count,
+                Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[1].DefRef);
-            Assert.AreEqual(1, spans[0].Subspans[1].Subspans.Count);
-            Assert.AreSame(implicitDef, spans[0].Subspans[1].Subspans[0].DefRef);
-            Assert.AreEqual("ITEM", spans[0].Subspans[1].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[1].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[1].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[1].Subspans.Count, Is.EqualTo(1));
+            Assert.That(spans[0].Subspans[1].Subspans[0].DefRef,
+                Is.SameAs(implicitDef));
+            Assert.That(spans[0].Subspans[1].Subspans[0].Value,
+                Is.EqualTo("ITEM"));
+            Assert.That(spans[0].Subspans[1].Subspans[0].Subspans.Count,
+                Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[2].DefRef);
-            Assert.AreEqual(1, spans[0].Subspans[2].Subspans.Count);
-            Assert.AreSame(implicitDef, spans[0].Subspans[2].Subspans[0].DefRef);
-            Assert.AreEqual("iTeM", spans[0].Subspans[2].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[2].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[2].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[2].Subspans.Count, Is.EqualTo(1));
+            Assert.That(spans[0].Subspans[2].Subspans[0].DefRef,
+                Is.SameAs(implicitDef));
+            Assert.That(spans[0].Subspans[2].Subspans[0].Value,
+                Is.EqualTo("iTeM"));
+            Assert.That(spans[0].Subspans[2].Subspans[0].Subspans.Count,
+                Is.EqualTo(0));
         }
 
         [Test]
@@ -945,29 +971,38 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(3, spans[0].Subspans.Count);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(3));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[0].DefRef);
-            Assert.AreEqual(1, spans[0].Subspans[0].Subspans.Count);
-            Assert.AreSame(implicitDef, spans[0].Subspans[0].Subspans[0].DefRef);
-            Assert.AreEqual("0", spans[0].Subspans[0].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[0].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[0].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[0].Subspans.Count, Is.EqualTo(1));
+            Assert.That(spans[0].Subspans[0].Subspans[0].DefRef,
+                Is.SameAs(implicitDef));
+            Assert.That(spans[0].Subspans[0].Subspans[0].Value,
+                Is.EqualTo("0"));
+            Assert.That(spans[0].Subspans[0].Subspans[0].Subspans.Count,
+                Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[1].DefRef);
-            Assert.AreEqual(1, spans[0].Subspans[1].Subspans.Count);
-            Assert.AreSame(implicitDef, spans[0].Subspans[1].Subspans[0].DefRef);
-            Assert.AreEqual("a", spans[0].Subspans[1].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[1].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[1].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[1].Subspans.Count, Is.EqualTo(1));
+            Assert.That(spans[0].Subspans[1].Subspans[0].DefRef,
+                Is.SameAs(implicitDef));
+            Assert.That(spans[0].Subspans[1].Subspans[0].Value,
+                Is.EqualTo("a"));
+            Assert.That(spans[0].Subspans[1].Subspans[0].Subspans.Count,
+                Is.EqualTo(0));
 
-            Assert.AreSame(itemDef, spans[0].Subspans[2].DefRef);
-            Assert.AreEqual(1, spans[0].Subspans[2].Subspans.Count);
-            Assert.AreSame(implicitDef, spans[0].Subspans[2].Subspans[0].DefRef);
-            Assert.AreEqual("A", spans[0].Subspans[2].Subspans[0].Value);
-            Assert.AreEqual(0, spans[0].Subspans[2].Subspans[0].Subspans.Count);
+            Assert.That(spans[0].Subspans[2].DefRef, Is.SameAs(itemDef));
+            Assert.That(spans[0].Subspans[2].Subspans.Count, Is.EqualTo(1));
+            Assert.That(spans[0].Subspans[2].Subspans[0].DefRef,
+                Is.SameAs(implicitDef));
+            Assert.That(spans[0].Subspans[2].Subspans[0].Value,
+                Is.EqualTo("A"));
+            Assert.That(spans[0].Subspans[2].Subspans[0].Subspans.Count,
+                Is.EqualTo(0));
         }
 
 
@@ -1101,20 +1136,24 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError>(errors[0]);
             var err = ((ParserError)errors[0]);
-            Assert.AreEqual(ParserError.UnexpectedEndOfInput, err.ErrorType);
-            Assert.AreEqual(1, err.Line);
-            Assert.AreEqual(15, err.Column);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.UnexpectedEndOfInput));
+            Assert.That(err.Line, Is.EqualTo(1));
+            Assert.That(err.Column, Is.EqualTo(15));
             Assert.IsInstanceOf<DefRefNode>(err.LastValidMatchingNode);
-            Assert.AreEqual("id-item2", (err.LastValidMatchingNode as DefRefNode).DefRef.Name);
+            Assert.That(
+                (err.LastValidMatchingNode as DefRefNode).DefRef.Name,
+                Is.EqualTo("id-item2"));
             Assert.IsNotNull(err.ExpectedNodes);
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
             Assert.IsInstanceOf<DefRefNode>(err.ExpectedNodes.First());
-            Assert.AreSame(itemDef, (err.ExpectedNodes.First() as DefRefNode).DefRef);
+            Assert.That((err.ExpectedNodes.First() as DefRefNode).DefRef,
+                Is.SameAs(itemDef));
         }
 
         [Test]
@@ -1140,20 +1179,24 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError>(errors[0]);
             var err = ((ParserError)errors[0]);
-            Assert.AreEqual(ParserError.UnexpectedEndOfInput, err.ErrorType);
-            Assert.AreEqual(1, err.Line);
-            Assert.AreEqual(14, err.Column);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.UnexpectedEndOfInput));
+            Assert.That(err.Line, Is.EqualTo(1));
+            Assert.That(err.Column, Is.EqualTo(14));
             Assert.IsInstanceOf<DefRefNode>(err.LastValidMatchingNode);
-            Assert.AreEqual("id-item2", (err.LastValidMatchingNode as DefRefNode).DefRef.Name);
+            Assert.That(
+                (err.LastValidMatchingNode as DefRefNode).DefRef.Name,
+                Is.EqualTo("id-item2"));
             Assert.IsNotNull(err.ExpectedNodes);
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
             Assert.IsInstanceOf<DefRefNode>(err.ExpectedNodes.First());
-            Assert.AreSame(itemDef, (err.ExpectedNodes.First() as DefRefNode).DefRef);
+            Assert.That((err.ExpectedNodes.First() as DefRefNode).DefRef,
+                Is.SameAs(itemDef));
         }
 
         [Test]
@@ -1180,20 +1223,25 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError>(errors[0]);
             var err = ((ParserError)errors[0]);
-            Assert.AreEqual(ParserError.UnexpectedEndOfInput, err.ErrorType);
-            Assert.AreEqual(1, err.Line);
-            Assert.AreEqual(13, err.Column);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.UnexpectedEndOfInput));
+            Assert.That(err.Line, Is.EqualTo(1));
+            Assert.That(err.Column, Is.EqualTo(13));
             Assert.IsInstanceOf<CharNode>(err.LastValidMatchingNode);
-            Assert.AreEqual("m", (err.LastValidMatchingNode as CharNode).CharClass.ToUndelimitedString());
+            Assert.That(
+                (err.LastValidMatchingNode as CharNode).CharClass
+                .ToUndelimitedString(),
+                Is.EqualTo("m"));
             Assert.IsNotNull(err.ExpectedNodes);
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
 //            Assert.IsInstanceOf<DefRefNode>(err.ExpectedNodes.First());
-//            Assert.AreSame(sequenceDef, (err.ExpectedNodes.First() as DefRefNode).DefRef);
+//            Assert.That((err.ExpectedNodes.First() as DefRefNode).DefRef,
+//                Is.SameAs(sequenceDef));
         }
 
         [Test]
@@ -1221,24 +1269,29 @@ namespace MetaphysicsIndustries.Giza.Test
             Span[] spans = parser.Parse(testInput.ToCharacterSource(), errors);
 
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<Token>>(errors[0]);
             var err = ((ParserError<Token>)errors[0]);
-            Assert.AreEqual(ParserError.InvalidInputElement, err.ErrorType);
-            Assert.AreEqual(1, err.Line);
-            Assert.AreEqual(9, err.Column);
-            Assert.AreEqual(8, err.Index);
-            Assert.AreEqual(8, err.OffendingInputElement.StartPosition.Index);
-            Assert.AreEqual(")", err.OffendingInputElement.Value);
-            Assert.AreSame(cparenDef, err.OffendingInputElement.Definition);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(err.Line, Is.EqualTo(1));
+            Assert.That(err.Column, Is.EqualTo(9));
+            Assert.That(err.Index, Is.EqualTo(8));
+            Assert.That(err.OffendingInputElement.StartPosition.Index,
+                Is.EqualTo(8));
+            Assert.That(err.OffendingInputElement.Value, Is.EqualTo(")"));
+            Assert.That(err.OffendingInputElement.Definition,
+                Is.SameAs(cparenDef));
             Assert.IsInstanceOf<DefRefNode>(err.LastValidMatchingNode);
-            Assert.AreSame(oparenDef, (err.LastValidMatchingNode as DefRefNode).DefRef);
+            Assert.That((err.LastValidMatchingNode as DefRefNode).DefRef,
+                Is.SameAs(oparenDef));
             Assert.IsNotNull(err.ExpectedNodes);
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
             Assert.IsInstanceOf<DefRefNode>(err.ExpectedNodes.First());
-            Assert.AreSame(sequenceDef, (err.ExpectedNodes.First() as DefRefNode).DefRef);
+            Assert.That((err.ExpectedNodes.First() as DefRefNode).DefRef,
+                Is.SameAs(sequenceDef));
         }
 
         [Test]
@@ -1414,24 +1467,29 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<Token>>(errors[0]);
             var err = ((ParserError<Token>)errors[0]);
-            Assert.AreEqual(ParserError.InvalidInputElement, err.ErrorType);
-            Assert.AreEqual(1, err.Line);
-            Assert.AreEqual(9, err.Column);
-            Assert.AreEqual(8, err.Index);
-            Assert.AreEqual(8, err.OffendingInputElement.StartPosition.Index);
-            Assert.AreEqual("two", err.OffendingInputElement.Value);
-            Assert.AreSame(implicitTwoDef, err.OffendingInputElement.Definition);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(err.Line, Is.EqualTo(1));
+            Assert.That(err.Column, Is.EqualTo(9));
+            Assert.That(err.Index, Is.EqualTo(8));
+            Assert.That(err.OffendingInputElement.StartPosition.Index,
+                Is.EqualTo(8));
+            Assert.That(err.OffendingInputElement.Value, Is.EqualTo("two"));
+            Assert.That(err.OffendingInputElement.Definition,
+                Is.SameAs(implicitTwoDef));
             Assert.IsInstanceOf<DefRefNode>(err.LastValidMatchingNode);
-            Assert.AreSame(implicitOpenDef, (err.LastValidMatchingNode as DefRefNode).DefRef);
+            Assert.That((err.LastValidMatchingNode as DefRefNode).DefRef,
+                Is.SameAs(implicitOpenDef));
             Assert.IsNotNull(err.ExpectedNodes);
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
             Assert.IsInstanceOf<DefRefNode>(err.ExpectedNodes.First());
-            Assert.AreSame(sequenceDef, (err.ExpectedNodes.First() as DefRefNode).DefRef);
+            Assert.That((err.ExpectedNodes.First() as DefRefNode).DefRef,
+                Is.SameAs(sequenceDef));
         }
 
         [Test]
@@ -1455,23 +1513,27 @@ namespace MetaphysicsIndustries.Giza.Test
             Span[] spans = parser.Parse(testInput.ToCharacterSource(), errors);
 
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var err = ((ParserError<InputChar>)errors[0]);
-            Assert.AreEqual(ParserError.InvalidInputElement, err.ErrorType);
-            Assert.AreEqual(1, err.Line);
-            Assert.AreEqual(9, err.Column);
-            Assert.AreEqual(8, err.Index);
-//            Assert.AreEqual(8, err.OffendingToken.StartPosition.Index);
-            Assert.AreEqual('$', err.OffendingInputElement.Value);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(err.Line, Is.EqualTo(1));
+            Assert.That(err.Column, Is.EqualTo(9));
+            Assert.That(err.Index, Is.EqualTo(8));
+//            Assert.That(err.OffendingToken.StartPosition.Index,
+//                Is.EqualTo(8));
+            Assert.That(err.OffendingInputElement.Value, Is.EqualTo('$'));
 //            Assert.IsInstanceOf<DefRefNode>(err.LastValidMatchingNode);
-//            Assert.AreSame(oparenDef, (err.LastValidMatchingNode as DefRefNode).DefRef);
+//            Assert.That((err.LastValidMatchingNode as DefRefNode).DefRef,
+//                Is.SameAs(oparenDef));
 //            Assert.IsNotNull(err.ExpectedNodes);
-//            Assert.AreEqual(1, err.ExpectedNodes.Count());
+//            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
 //            Assert.IsInstanceOf<DefRefNode>(err.ExpectedNodes.First());
-//            Assert.AreSame(sequenceDef, (err.ExpectedNodes.First() as DefRefNode).DefRef);
+//            Assert.That((err.ExpectedNodes.First() as DefRefNode).DefRef,
+//                Is.SameAs(sequenceDef));
         }
 
         [Test]
@@ -1580,20 +1642,25 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<Token>>(errors[0]);
             var err = ((ParserError<Token>)errors[0]);
-            Assert.AreEqual(ParserError.ExcessRemainingInput, err.ErrorType);
-            Assert.AreEqual(1, err.Line);
-            Assert.AreEqual(15, err.Column);
-            Assert.AreEqual(14, err.Index);
-            Assert.AreEqual(14, err.OffendingInputElement.StartPosition.Index);
-            Assert.AreEqual("four", err.OffendingInputElement.Value);
-            Assert.AreSame(fourDef, err.OffendingInputElement.Definition);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.ExcessRemainingInput));
+            Assert.That(err.Line, Is.EqualTo(1));
+            Assert.That(err.Column, Is.EqualTo(15));
+            Assert.That(err.Index, Is.EqualTo(14));
+            Assert.That(err.OffendingInputElement.StartPosition.Index,
+                Is.EqualTo(14));
+            Assert.That(err.OffendingInputElement.Value,
+                Is.EqualTo("four"));
+            Assert.That(err.OffendingInputElement.Definition,
+                Is.SameAs(fourDef));
             Assert.IsInstanceOf<DefRefNode>(err.LastValidMatchingNode);
-            Assert.AreSame(threeDef, (err.LastValidMatchingNode as DefRefNode).DefRef);
+            Assert.That((err.LastValidMatchingNode as DefRefNode).DefRef,
+                Is.SameAs(threeDef));
             Assert.IsNull(err.ExpectedNodes);
         }
 
@@ -1625,7 +1692,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var spans = parser.Parse(testInput, errors);
 
             Assert.IsNotNull(spans);
-            Assert.AreEqual(2, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(2));
 
         }
 
@@ -1738,12 +1805,14 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
-            Assert.AreEqual(2, errors.Count);
+            Assert.That(spans.Length, Is.EqualTo(0));
+            Assert.That(errors.Count, Is.EqualTo(2));
             Assert.IsInstanceOf<MockError>(errors[0]);
-            Assert.AreEqual(MockError.MockErrorType, errors[0].ErrorType);
+            Assert.That(errors[0].ErrorType,
+                Is.EqualTo(MockError.MockErrorType));
             Assert.IsInstanceOf<MockError>(errors[1]);
-            Assert.AreEqual(MockError.MockErrorType2, errors[1].ErrorType);
+            Assert.That(errors[1].ErrorType,
+                Is.EqualTo(MockError.MockErrorType2));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/PriorityQueueTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/PriorityQueueTest.cs
@@ -1,5 +1,4 @@
-﻿
-// MetaphysicsIndustries.Giza - A Parsing System
+﻿// MetaphysicsIndustries.Giza - A Parsing System
 // Copyright (C) 2008-2021 Metaphysics Industries, Inc.
 //
 // This library is free software; you can redistribute it and/or
@@ -35,7 +34,7 @@ namespace MetaphysicsIndustries.Giza.Test
             pq.Enqueue("something", 3);
 
             // assertion
-            Assert.AreEqual(1, pq.Count);
+            Assert.That(pq.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -48,8 +47,8 @@ namespace MetaphysicsIndustries.Giza.Test
             pq.Enqueue("something2", 4);
 
             // assertion
-            Assert.AreEqual(1, pq.Count);
-            Assert.AreEqual("something2", pq.Peek());
+            Assert.That(pq.Count, Is.EqualTo(1));
+            Assert.That(pq.Peek(), Is.EqualTo("something2"));
         }
 
         [Test]
@@ -58,15 +57,15 @@ namespace MetaphysicsIndustries.Giza.Test
             // setup
             var pq = new PriorityQueue<string, int>();
             pq.Enqueue("item", 2);
-            Assert.AreEqual(1, pq.Count);
-            Assert.AreEqual("item", pq.Peek());
+            Assert.That(pq.Count, Is.EqualTo(1));
+            Assert.That(pq.Peek(), Is.EqualTo("item"));
 
             // action
             string value = pq.Dequeue();
 
             // assertions
-            Assert.AreEqual(0, pq.Count);
-            Assert.AreSame("item", value);
+            Assert.That(pq.Count, Is.EqualTo(0));
+            Assert.That(value, Is.SameAs("item"));
         }
 
         [Test]
@@ -85,8 +84,8 @@ namespace MetaphysicsIndustries.Giza.Test
             pq.Enqueue("something else", 5);
 
             // assertion
-            Assert.AreEqual(2, pq.Count);
-            Assert.AreEqual("something else", pq.Peek());
+            Assert.That(pq.Count, Is.EqualTo(2));
+            Assert.That(pq.Peek(), Is.EqualTo("something else"));
         }
 
         [Test]
@@ -100,8 +99,8 @@ namespace MetaphysicsIndustries.Giza.Test
             pq.Enqueue("low", 1);
 
             // assertion
-            Assert.AreEqual(2, pq.Count);
-            Assert.AreEqual("high", pq.Peek());
+            Assert.That(pq.Count, Is.EqualTo(2));
+            Assert.That(pq.Peek(), Is.EqualTo("high"));
         }
 
         [Test]
@@ -118,9 +117,9 @@ namespace MetaphysicsIndustries.Giza.Test
             pq.CopyTo(array, 0);
 
             // assertion
-            Assert.AreEqual("high", array[0]);
-            Assert.AreEqual("middle", array[1]);
-            Assert.AreEqual("low", array[2]);
+            Assert.That(array[0], Is.EqualTo("high"));
+            Assert.That(array[1], Is.EqualTo("middle"));
+            Assert.That(array[2], Is.EqualTo("low"));
         }
 
         [Test]
@@ -137,9 +136,9 @@ namespace MetaphysicsIndustries.Giza.Test
             pq.CopyTo(array, 0);
 
             // assertion
-            Assert.AreEqual("high", array[0]);
-            Assert.AreEqual("middle", array[1]);
-            Assert.AreEqual("low", array[2]);
+            Assert.That(array[0], Is.EqualTo("high"));
+            Assert.That(array[1], Is.EqualTo("middle"));
+            Assert.That(array[2], Is.EqualTo("low"));
         }
 
         [Test]
@@ -156,9 +155,9 @@ namespace MetaphysicsIndustries.Giza.Test
             pq.CopyTo(array, 0);
 
             // assertion
-            Assert.AreEqual("high", array[0]);
-            Assert.AreEqual("high2", array[1]);
-            Assert.AreEqual("low", array[2]);
+            Assert.That(array[0], Is.EqualTo("high"));
+            Assert.That(array[1], Is.EqualTo("high2"));
+            Assert.That(array[2], Is.EqualTo("low"));
         }
 
         [Test]
@@ -175,9 +174,9 @@ namespace MetaphysicsIndustries.Giza.Test
             pq.CopyTo(array, 0);
 
             // assertion
-            Assert.AreEqual("high", array[0]);
-            Assert.AreEqual("low", array[1]);
-            Assert.AreEqual("low2", array[2]);
+            Assert.That(array[0], Is.EqualTo("high"));
+            Assert.That(array[1], Is.EqualTo("low"));
+            Assert.That(array[2], Is.EqualTo("low2"));
         }
 
         [Test]
@@ -194,9 +193,9 @@ namespace MetaphysicsIndustries.Giza.Test
             pq.CopyTo(array, 0);
 
             // assertion
-            Assert.AreEqual("low", array[0]);
-            Assert.AreEqual("high", array[1]);
-            Assert.AreEqual("high2", array[2]);
+            Assert.That(array[0], Is.EqualTo("low"));
+            Assert.That(array[1], Is.EqualTo("high"));
+            Assert.That(array[2], Is.EqualTo("high2"));
         }
 
         [Test]
@@ -213,10 +212,9 @@ namespace MetaphysicsIndustries.Giza.Test
             pq.CopyTo(array, 0);
 
             // assertion
-            Assert.AreEqual("low", array[0]);
-            Assert.AreEqual("low2", array[1]);
-            Assert.AreEqual("high", array[2]);
+            Assert.That(array[0], Is.EqualTo("low"));
+            Assert.That(array[1], Is.EqualTo("low2"));
+            Assert.That(array[2], Is.EqualTo("high"));
         }
     }
 }
-

--- a/MetaphysicsIndustries.Giza.Test/SpanCheckerTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/SpanCheckerTest.cs
@@ -1,5 +1,4 @@
-﻿
-// MetaphysicsIndustries.Giza - A Parsing System
+﻿// MetaphysicsIndustries.Giza - A Parsing System
 // Copyright (C) 2008-2021 Metaphysics Industries, Inc.
 //
 // This library is free software; you can redistribute it and/or
@@ -59,7 +58,7 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -92,11 +91,11 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<SpanError>(errors[0]);
             var e = (SpanError)errors[0];
-            Assert.AreEqual(SpanError.BadStartingNode, e.ErrorType);
-            Assert.AreSame(span.Subspans[0], e.Span);
+            Assert.That(e.ErrorType, Is.EqualTo(SpanError.BadStartingNode));
+            Assert.That(e.Span, Is.SameAs(span.Subspans[0]));
         }
 
         [Test]
@@ -129,11 +128,11 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<SpanError>(errors[0]);
             var e = (SpanError)errors[0];
-            Assert.AreEqual(SpanError.BadEndingNode, e.ErrorType);
-            Assert.AreSame(span.Subspans[3], e.Span);
+            Assert.That(e.ErrorType, Is.EqualTo(SpanError.BadEndingNode));
+            Assert.That(e.Span, Is.SameAs(span.Subspans[3]));
         }
 
         [Test]
@@ -158,11 +157,11 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<SpanError>(errors[0]);
             var e = (SpanError)errors[0];
-            Assert.AreEqual(SpanError.BadFollow, e.ErrorType);
-            Assert.AreSame(span.Subspans[1], e.Span);
+            Assert.That(e.ErrorType, Is.EqualTo(SpanError.BadFollow));
+            Assert.That(e.Span, Is.SameAs(span.Subspans[1]));
         }
 
         [Test]
@@ -211,8 +210,9 @@ namespace MetaphysicsIndustries.Giza.Test
                 }
             }
             Assert.IsNotNull(e);
-            Assert.AreEqual(SpanError.NodeInWrongDefinition, e.ErrorType);
-            Assert.AreSame(span.Subspans[2], e.Span);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(SpanError.NodeInWrongDefinition));
+            Assert.That(e.Span, Is.SameAs(span.Subspans[2]));
         }
 
         [Test]
@@ -269,11 +269,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<SpanError>(errors[0]);
             var e = (SpanError)errors[0];
-            Assert.AreEqual(SpanError.NodeInWrongDefinition, e.ErrorType);
-            Assert.AreSame(span.Subspans[1], e.Span);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(SpanError.NodeInWrongDefinition));
+            Assert.That(e.Span, Is.SameAs(span.Subspans[1]));
         }
 
         [Test]
@@ -290,11 +291,11 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<SpanError>(errors[0]);
             var e = (SpanError)errors[0];
-            Assert.AreEqual(SpanError.SpanHasNoSubspans, e.ErrorType);
-            Assert.AreSame(span, e.Span);
+            Assert.That(e.ErrorType, Is.EqualTo(SpanError.SpanHasNoSubspans));
+            Assert.That(e.Span, Is.SameAs(span));
         }
 
         [Test]
@@ -340,9 +341,9 @@ namespace MetaphysicsIndustries.Giza.Test
                 }
             }
             Assert.IsNotNull(e);
-            Assert.AreEqual(SpanError.CycleInSubspans, e.ErrorType);
-            Assert.AreSame(span, e.Span);
-            Assert.AreSame(span.Subspans[4], e.Span);
+            Assert.That(e.ErrorType, Is.EqualTo(SpanError.CycleInSubspans));
+            Assert.That(e.Span, Is.SameAs(span));
+            Assert.That(e.Span, Is.SameAs(span.Subspans[4]));
         }
 
         [Test]
@@ -384,12 +385,12 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<SpanError>(errors[0]);
             var e = (SpanError)errors[0];
-            Assert.AreEqual(SpanError.CycleInSubspans, e.ErrorType);
-            Assert.AreSame(span, e.Span);
-            Assert.AreSame(span.Subspans[1], e.Span);
+            Assert.That(e.ErrorType, Is.EqualTo(SpanError.CycleInSubspans));
+            Assert.That(e.Span, Is.SameAs(span));
+            Assert.That(e.Span, Is.SameAs(span.Subspans[1]));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/SpannerTests/AtomicTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/SpannerTests/AtomicTest.cs
@@ -57,23 +57,23 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsEmpty(errors);
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(1));
             var s = spans[0];
-            Assert.AreSame(sequenceDef, s.DefRef);
-            Assert.AreEqual(1, s.Subspans.Count);
+            Assert.That(s.DefRef, Is.SameAs(sequenceDef));
+            Assert.That(s.Subspans.Count, Is.EqualTo(1));
             var s2 = s.Subspans[0];
-            Assert.AreSame(lettersDef, s2.DefRef);
-            Assert.AreEqual(3, s2.Subspans.Count);
+            Assert.That(s2.DefRef, Is.SameAs(lettersDef));
+            Assert.That(s2.Subspans.Count, Is.EqualTo(3));
 
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[0].Node);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[1].Node);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[2].Node);
+            Assert.That(s2.Subspans[0].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[1].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[2].Node, Is.SameAs(lettersDef.Nodes[0]));
             Assert.IsEmpty(s2.Subspans[0].Subspans);
             Assert.IsEmpty(s2.Subspans[1].Subspans);
             Assert.IsEmpty(s2.Subspans[2].Subspans);
-            Assert.AreEqual("a", s2.Subspans[0].Value);
-            Assert.AreEqual("b", s2.Subspans[1].Value);
-            Assert.AreEqual("c", s2.Subspans[2].Value);
+            Assert.That(s2.Subspans[0].Value, Is.EqualTo("a"));
+            Assert.That(s2.Subspans[1].Value, Is.EqualTo("b"));
+            Assert.That(s2.Subspans[2].Value, Is.EqualTo("c"));
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsEmpty(errors);
             Assert.IsNotNull(spans);
-            Assert.AreEqual(4, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(4));
 
             // sequence
             //    |
@@ -125,88 +125,94 @@ namespace MetaphysicsIndustries.Giza.Test
             //             /      |     \
             // letters('a') letters('b') letters('c')
 
-            Assert.AreEqual(1, spans.Count(x => x.Subspans.Count == 1));    // abc
-            Assert.AreEqual(1, spans.Count(x => x.Subspans.Count == 3));    // a b c
-            Assert.AreEqual(2, spans.Count(x => x.Subspans.Count == 2));
-            Assert.AreEqual(1, spans.Count(
+            Assert.That(spans.Count(x => x.Subspans.Count == 1),
+                Is.EqualTo(1));                                      // abc
+            Assert.That(spans.Count(x => x.Subspans.Count == 3),
+                Is.EqualTo(1));                                      // a b c
+            Assert.That(spans.Count(x => x.Subspans.Count == 2),
+                Is.EqualTo(2));
+            Assert.That(spans.Count(
                 x =>
                 x.Subspans.Count == 2 &&
                 x.Subspans[0].Subspans.Count == 1 &&
-                x.Subspans[1].Subspans.Count == 2));                    // a bc
-            Assert.AreEqual(1, spans.Count(
+                x.Subspans[1].Subspans.Count == 2), Is.EqualTo(1));  // a bc
+            Assert.That(spans.Count(
                 x =>
                 x.Subspans.Count == 2 &&
                 x.Subspans[0].Subspans.Count == 2 &&
-                x.Subspans[1].Subspans.Count == 1));                    // ab c
+                x.Subspans[1].Subspans.Count == 1), Is.EqualTo(1));  // ab c
 
             Span s;
             Span s2;
 
             s = spans.First(x => x.Subspans.Count == 1);    //abc
-            Assert.AreSame(sequenceDef, s.DefRef);
+            Assert.That(s.DefRef, Is.SameAs(sequenceDef));
             s2 = s.Subspans[0];
-            Assert.AreSame(lettersDef, s2.DefRef);
-            Assert.AreEqual(3, s2.Subspans.Count);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[0].Node);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[1].Node);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[2].Node);
-            Assert.AreEqual("a", s2.Subspans[0].Value);
-            Assert.AreEqual("b", s2.Subspans[1].Value);
-            Assert.AreEqual("c", s2.Subspans[2].Value);
+            Assert.That(s2.DefRef, Is.SameAs(lettersDef));
+            Assert.That(s2.Subspans.Count, Is.EqualTo(3));
+            Assert.That(s2.Subspans[0].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[1].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[2].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[0].Value, Is.EqualTo("a"));
+            Assert.That(s2.Subspans[1].Value, Is.EqualTo("b"));
+            Assert.That(s2.Subspans[2].Value, Is.EqualTo("c"));
             Assert.IsEmpty(s2.Subspans[0].Subspans);
             Assert.IsEmpty(s2.Subspans[1].Subspans);
             Assert.IsEmpty(s2.Subspans[2].Subspans);
 
             s = spans.First(x => x.Subspans.Count == 2 && x.Subspans[0].Subspans.Count == 1); // a bc
-            Assert.AreSame(sequenceDef, s.DefRef);
+            Assert.That(s.DefRef, Is.SameAs(sequenceDef));
             s2 = s.Subspans[0];
-            Assert.AreSame(lettersDef, s2.DefRef);
-            Assert.AreEqual(1, s2.Subspans.Count);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[0].Node);
-            Assert.AreEqual("a", s2.Subspans[0].Value);
+            Assert.That(s2.DefRef, Is.SameAs(lettersDef));
+            Assert.That(s2.Subspans.Count, Is.EqualTo(1));
+            Assert.That(s2.Subspans[0].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[0].Value, Is.EqualTo("a"));
             Assert.IsEmpty(s2.Subspans[0].Subspans);
             s2 = s.Subspans[1];
-            Assert.AreSame(lettersDef, s2.DefRef);
-            Assert.AreEqual(2, s2.Subspans.Count);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[0].Node);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[1].Node);
-            Assert.AreEqual("b", s2.Subspans[0].Value);
-            Assert.AreEqual("c", s2.Subspans[1].Value);
+            Assert.That(s2.DefRef, Is.SameAs(lettersDef));
+            Assert.That(s2.Subspans.Count, Is.EqualTo(2));
+            Assert.That(s2.Subspans[0].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[1].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[0].Value, Is.EqualTo("b"));
+            Assert.That(s2.Subspans[1].Value, Is.EqualTo("c"));
             Assert.IsEmpty(s2.Subspans[0].Subspans);
             Assert.IsEmpty(s2.Subspans[1].Subspans);
 
             s = spans.First(x => x.Subspans.Count == 2 && x.Subspans[0].Subspans.Count == 2); // ab c
-            Assert.AreSame(sequenceDef, s.DefRef);
+            Assert.That(s.DefRef, Is.SameAs(sequenceDef));
             s2 = s.Subspans[0];
-            Assert.AreSame(lettersDef, s2.DefRef);
-            Assert.AreEqual(2, s2.Subspans.Count);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[0].Node);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[1].Node);
-            Assert.AreEqual("a", s2.Subspans[0].Value);
-            Assert.AreEqual("b", s2.Subspans[1].Value);
+            Assert.That(s2.DefRef, Is.SameAs(lettersDef));
+            Assert.That(s2.Subspans.Count, Is.EqualTo(2));
+            Assert.That(s2.Subspans[0].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[1].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[0].Value, Is.EqualTo("a"));
+            Assert.That(s2.Subspans[1].Value, Is.EqualTo("b"));
             Assert.IsEmpty(s2.Subspans[0].Subspans);
             Assert.IsEmpty(s2.Subspans[1].Subspans);
             s2 = s.Subspans[1];
-            Assert.AreSame(lettersDef, s2.DefRef);
-            Assert.AreEqual(1, s2.Subspans.Count);
-            Assert.AreSame(lettersDef.Nodes[0], s2.Subspans[0].Node);
-            Assert.AreEqual("c", s2.Subspans[0].Value);
+            Assert.That(s2.DefRef, Is.SameAs(lettersDef));
+            Assert.That(s2.Subspans.Count, Is.EqualTo(1));
+            Assert.That(s2.Subspans[0].Node, Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s2.Subspans[0].Value, Is.EqualTo("c"));
             Assert.IsEmpty(s2.Subspans[0].Subspans);
 
             s = spans.First(x => x.Subspans.Count == 3);    // a b c
-            Assert.AreSame(sequenceDef, s.DefRef);
-            Assert.AreSame(lettersDef, s.Subspans[0].DefRef);
-            Assert.AreSame(lettersDef, s.Subspans[1].DefRef);
-            Assert.AreSame(lettersDef, s.Subspans[2].DefRef);
-            Assert.AreEqual(1, s.Subspans[0].Subspans.Count);
-            Assert.AreEqual(1, s.Subspans[1].Subspans.Count);
-            Assert.AreEqual(1, s.Subspans[2].Subspans.Count);
-            Assert.AreSame(lettersDef.Nodes[0], s.Subspans[0].Subspans[0].Node);
-            Assert.AreSame(lettersDef.Nodes[0], s.Subspans[1].Subspans[0].Node);
-            Assert.AreSame(lettersDef.Nodes[0], s.Subspans[2].Subspans[0].Node);
-            Assert.AreEqual("a", s.Subspans[0].Subspans[0].Value);
-            Assert.AreEqual("b", s.Subspans[1].Subspans[0].Value);
-            Assert.AreEqual("c", s.Subspans[2].Subspans[0].Value);
+            Assert.That(s.DefRef, Is.SameAs(sequenceDef));
+            Assert.That(s.Subspans[0].DefRef, Is.SameAs(lettersDef));
+            Assert.That(s.Subspans[1].DefRef, Is.SameAs(lettersDef));
+            Assert.That(s.Subspans[2].DefRef, Is.SameAs(lettersDef));
+            Assert.That(s.Subspans[0].Subspans.Count, Is.EqualTo(1));
+            Assert.That(s.Subspans[1].Subspans.Count, Is.EqualTo(1));
+            Assert.That(s.Subspans[2].Subspans.Count, Is.EqualTo(1));
+            Assert.That(s.Subspans[0].Subspans[0].Node,
+             Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s.Subspans[1].Subspans[0].Node,
+                Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s.Subspans[2].Subspans[0].Node,
+                Is.SameAs(lettersDef.Nodes[0]));
+            Assert.That(s.Subspans[0].Subspans[0].Value, Is.EqualTo("a"));
+            Assert.That(s.Subspans[1].Subspans[0].Value, Is.EqualTo("b"));
+            Assert.That(s.Subspans[2].Subspans[0].Value, Is.EqualTo("c"));
             Assert.IsEmpty(s.Subspans[0].Subspans[0].Subspans);
             Assert.IsEmpty(s.Subspans[1].Subspans[0].Subspans);
             Assert.IsEmpty(s.Subspans[2].Subspans[0].Subspans);

--- a/MetaphysicsIndustries.Giza.Test/SpannerTests/BasicTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/SpannerTests/BasicTest.cs
@@ -66,13 +66,13 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
             Span[] spans = s.Process("qwer".ToCharacterSource(), errors);
 
             // assertions
-            Assert.AreEqual(1, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(1));
             Assert.IsEmpty(errors);
 
             // action
             spans = s.Process("asdf".ToCharacterSource(), errors);
             // assertions
-            Assert.AreEqual(1, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(1));
             Assert.IsEmpty(errors);
         }
 
@@ -92,19 +92,23 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
             Span[] spans = s.Process(testGrammarText.ToCharacterSource(), errors);
 
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var err = ((ParserError<InputChar>)errors[0]);
-            Assert.AreEqual(ParserError.InvalidInputElement, err.ErrorType);
-            Assert.AreEqual('w', err.OffendingInputElement.Value);
-            Assert.AreEqual(4, err.Position.Line);
-            Assert.AreEqual(2, err.Position.Column);
-            Assert.AreEqual(74, err.Position.Index);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(err.OffendingInputElement.Value, Is.EqualTo('w'));
+            Assert.That(err.Position.Line, Is.EqualTo(4));
+            Assert.That(err.Position.Column, Is.EqualTo(2));
+            Assert.That(err.Position.Index, Is.EqualTo(74));
             Assert.IsInstanceOf<CharNode>(err.LastValidMatchingNode);
             var charnode = (err.LastValidMatchingNode as CharNode);
-            Assert.AreEqual("<", charnode.CharClass.ToUndelimitedString());
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
-            Assert.AreEqual("directive-item", (err.ExpectedNodes.First() as DefRefNode).DefRef.Name);
+            Assert.That(charnode.CharClass.ToUndelimitedString(),
+                Is.EqualTo("<"));
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
+            Assert.That(
+                (err.ExpectedNodes.First() as DefRefNode).DefRef.Name,
+                Is.EqualTo("directive-item"));
         }
 
         [Test()]
@@ -123,23 +127,28 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
             Span[] spans = s.Process(testGrammarText.ToCharacterSource(), errors);
 
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var err = ((ParserError<InputChar>)errors[0]);
-            Assert.AreEqual(ParserError.InvalidInputElement, err.ErrorType);
-            Assert.AreEqual('w', err.OffendingInputElement.Value);
-            Assert.AreEqual(4, err.Position.Line);
-            Assert.AreEqual(2, err.Position.Column);
-            Assert.AreEqual(74, err.Position.Index);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(err.OffendingInputElement.Value, Is.EqualTo('w'));
+            Assert.That(err.Position.Line, Is.EqualTo(4));
+            Assert.That(err.Position.Column, Is.EqualTo(2));
+            Assert.That(err.Position.Index, Is.EqualTo(74));
             Assert.IsInstanceOf<CharNode>(err.LastValidMatchingNode);
             var charnode = (err.LastValidMatchingNode as CharNode);
-            Assert.AreEqual("<", charnode.CharClass.ToUndelimitedString());
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
-            Assert.AreEqual("directive-item", (err.ExpectedNodes.First() as DefRefNode).DefRef.Name);
+            Assert.That(charnode.CharClass.ToUndelimitedString(),
+                Is.EqualTo("<"));
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
+            Assert.That(
+                (err.ExpectedNodes.First() as DefRefNode).DefRef.Name,
+                Is.EqualTo("directive-item"));
 
-            Assert.AreEqual(
-                "Invalid token 'w' at position 4,2 (index 74). Expected directive-item.",
-                err.Description);
+            Assert.That(
+                err.Description,
+                Is.EqualTo("Invalid token 'w' at position 4,2 (index 74). " +
+                           "Expected directive-item."));
         }
 
         [Test()]
@@ -219,17 +228,20 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var err = ((ParserError<InputChar>)errors[0]);
-            Assert.AreEqual(ParserError.InvalidInputElement, err.ErrorType);
-            Assert.AreEqual('$', err.OffendingInputElement.Value);
-            Assert.AreEqual(1, err.Position.Line);
-            Assert.AreEqual(1, err.Position.Column);
-            Assert.AreEqual(0, err.Position.Index);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(err.OffendingInputElement.Value, Is.EqualTo('$'));
+            Assert.That(err.Position.Line, Is.EqualTo(1));
+            Assert.That(err.Position.Column, Is.EqualTo(1));
+            Assert.That(err.Position.Index, Is.EqualTo(0));
             Assert.IsNull(err.LastValidMatchingNode);
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
-            Assert.AreEqual("item", (err.ExpectedNodes.First() as DefRefNode).DefRef.Name);
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
+            Assert.That(
+                (err.ExpectedNodes.First() as DefRefNode).DefRef.Name,
+                Is.EqualTo("item"));
         }
 
         static NGrammar CreateGrammarForTestUnexpectedEndOfInput()
@@ -331,21 +343,27 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError>(errors[0]);
             var err = ((ParserError)errors[0]);
-            Assert.AreEqual(ParserError.UnexpectedEndOfInput, err.ErrorType);
-            Assert.AreEqual(1, err.Position.Line);
-            Assert.AreEqual(15, err.Position.Column);
-            Assert.AreEqual(14, err.Position.Index);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.UnexpectedEndOfInput));
+            Assert.That(err.Position.Line, Is.EqualTo(1));
+            Assert.That(err.Position.Column, Is.EqualTo(15));
+            Assert.That(err.Position.Index, Is.EqualTo(14));
             Assert.IsInstanceOf<DefRefNode>(err.LastValidMatchingNode);
-            Assert.AreEqual("sequence", (err.LastValidMatchingNode as DefRefNode).DefRef.Name);
+            Assert.That(
+                (err.LastValidMatchingNode as DefRefNode).DefRef.Name,
+                Is.EqualTo("sequence"));
             Assert.IsNotNull(err.ExpectedNodes);
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
             Assert.IsInstanceOf<CharNode>(err.ExpectedNodes.First());
-            Assert.AreEqual(")", (err.ExpectedNodes.First() as CharNode).CharClass.ToUndelimitedString());
+            Assert.That(
+                (err.ExpectedNodes.First() as CharNode).CharClass
+                .ToUndelimitedString(),
+                Is.EqualTo(")"));
         }
 
         [Test]
@@ -370,21 +388,27 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError>(errors[0]);
             var err = ((ParserError)errors[0]);
-            Assert.AreEqual(ParserError.UnexpectedEndOfInput, err.ErrorType);
-            Assert.AreEqual(1, err.Position.Line);
-            Assert.AreEqual(14, err.Position.Column);
-            Assert.AreEqual(13, err.Position.Index);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.UnexpectedEndOfInput));
+            Assert.That(err.Position.Line, Is.EqualTo(1));
+            Assert.That(err.Position.Column, Is.EqualTo(14));
+            Assert.That(err.Position.Index, Is.EqualTo(13));
             Assert.IsInstanceOf<DefRefNode>(err.LastValidMatchingNode);
-            Assert.AreEqual("sequence", (err.LastValidMatchingNode as DefRefNode).DefRef.Name);
+            Assert.That(
+                (err.LastValidMatchingNode as DefRefNode).DefRef.Name,
+                Is.EqualTo("sequence"));
             Assert.IsNotNull(err.ExpectedNodes);
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
             Assert.IsInstanceOf<CharNode>(err.ExpectedNodes.First());
-            Assert.AreEqual(")", (err.ExpectedNodes.First() as CharNode).CharClass.ToUndelimitedString());
+            Assert.That(
+                (err.ExpectedNodes.First() as CharNode).CharClass
+                .ToUndelimitedString(),
+                Is.EqualTo(")"));
         }
 
         [Test]
@@ -409,19 +433,23 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError>(errors[0]);
             var err = ((ParserError)errors[0]);
-            Assert.AreEqual(ParserError.UnexpectedEndOfInput, err.ErrorType);
-            Assert.AreEqual(1, err.Position.Line);
-            Assert.AreEqual(13, err.Position.Column);
-            Assert.AreEqual(12, err.Position.Index);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.UnexpectedEndOfInput));
+            Assert.That(err.Position.Line, Is.EqualTo(1));
+            Assert.That(err.Position.Column, Is.EqualTo(13));
+            Assert.That(err.Position.Index, Is.EqualTo(12));
             Assert.IsInstanceOf<CharNode>(err.LastValidMatchingNode);
-            Assert.AreEqual("m", (err.LastValidMatchingNode as CharNode).CharClass.ToUndelimitedString());
+            Assert.That(
+                (err.LastValidMatchingNode as CharNode).CharClass
+                .ToUndelimitedString(),
+                Is.EqualTo("m"));
             Assert.IsNotNull(err.ExpectedNodes);
-            Assert.AreEqual(1, err.ExpectedNodes.Count());
+            Assert.That(err.ExpectedNodes.Count(), Is.EqualTo(1));
             Assert.IsInstanceOf<CharNode>(err.ExpectedNodes.First());
             var expectedChar = (err.ExpectedNodes.First() as CharNode).CharClass.ToUndelimitedString();
             Assert.True(expectedChar == "1" || expectedChar == "2");
@@ -511,17 +539,20 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
             Assert.IsNotNull(errors);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError>(errors[0]);
             var err = ((ParserError)errors[0]);
-            Assert.AreEqual(ParserError.ExcessRemainingInput, err.ErrorType);
-            Assert.AreEqual(1, err.Position.Line);
-            Assert.AreEqual(15, err.Position.Column);
-            Assert.AreEqual(14, err.Position.Index);
+            Assert.That(err.ErrorType,
+                Is.EqualTo(ParserError.ExcessRemainingInput));
+            Assert.That(err.Position.Line, Is.EqualTo(1));
+            Assert.That(err.Position.Column, Is.EqualTo(15));
+            Assert.That(err.Position.Index, Is.EqualTo(14));
             Assert.IsInstanceOf<DefRefNode>(err.LastValidMatchingNode);
-            Assert.AreEqual("sequence", (err.LastValidMatchingNode as DefRefNode).DefRef.Name);
+            Assert.That(
+                (err.LastValidMatchingNode as DefRefNode).DefRef.Name,
+                Is.EqualTo("sequence"));
             Assert.IsNull(err.ExpectedNodes);
         }
 
@@ -590,7 +621,7 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
             Assert.IsEmpty(tokens);
             Assert.IsNotNull(errors);
             Assert.IsEmpty(errors);
-            Assert.AreEqual(5, endOfInputPosition.Index);
+            Assert.That(endOfInputPosition.Index, Is.EqualTo(5));
         }
 
         [Test]
@@ -622,7 +653,7 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
             Assert.IsEmpty(tokens);
             Assert.IsNotNull(errors);
             Assert.IsEmpty(errors);
-            Assert.AreEqual(6, endOfInputPosition.Index);
+            Assert.That(endOfInputPosition.Index, Is.EqualTo(6));
         }
 
         [Test]
@@ -654,7 +685,7 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
             Assert.IsEmpty(tokens);
             Assert.IsNotNull(errors);
             Assert.IsEmpty(errors);
-            Assert.AreEqual(6, endOfInputPosition.Index);
+            Assert.That(endOfInputPosition.Index, Is.EqualTo(6));
         }
 
         [Test]
@@ -743,36 +774,36 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsNotNull(errors);
-            Assert.AreEqual(0, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(0));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(1));
             var span = spans[0];
-            Assert.AreSame(formatDef, span.DefRef);
-            Assert.AreEqual(3, span.Subspans.Count);
+            Assert.That(span.DefRef, Is.SameAs(formatDef));
+            Assert.That(span.Subspans.Count, Is.EqualTo(3));
             var s0 = span.Subspans[0];
             var s1 = span.Subspans[1];
             var s2 = span.Subspans[2];
-            Assert.AreSame(textDef, s0.DefRef);
-            Assert.AreEqual("leading ", s0.CollectValue());
+            Assert.That(s0.DefRef, Is.SameAs(textDef));
+            Assert.That(s0.CollectValue(), Is.EqualTo("leading "));
 
-            Assert.AreSame(paramDef, s1.DefRef);
-            Assert.AreEqual(3, s1.Subspans.Count);
+            Assert.That(s1.DefRef, Is.SameAs(paramDef));
+            Assert.That(s1.Subspans.Count, Is.EqualTo(3));
             var s10 = s1.Subspans[0];
             var s11 = s1.Subspans[1];
             var s12 = s1.Subspans[2];
-            Assert.AreSame(paramDef.Nodes[0], s10.Node);
+            Assert.That(s10.Node, Is.SameAs(paramDef.Nodes[0]));
             Assert.IsNull(s10.DefRef);
-            Assert.AreEqual(0, s10.Subspans.Count);
-            Assert.AreEqual("{", s10.Value);
-            Assert.AreSame(nameDef, s11.DefRef);
-            Assert.AreEqual("delimited", s11.CollectValue());
-            Assert.AreSame(paramDef.Nodes[4], s12.Node);
+            Assert.That(s10.Subspans.Count, Is.EqualTo(0));
+            Assert.That(s10.Value, Is.EqualTo("{"));
+            Assert.That(s11.DefRef, Is.SameAs(nameDef));
+            Assert.That(s11.CollectValue(), Is.EqualTo("delimited"));
+            Assert.That(s12.Node, Is.SameAs(paramDef.Nodes[4]));
             Assert.IsNull(s12.DefRef);
-            Assert.AreEqual(0, s12.Subspans.Count);
-            Assert.AreEqual("}", s12.Value);
+            Assert.That(s12.Subspans.Count, Is.EqualTo(0));
+            Assert.That(s12.Value, Is.EqualTo("}"));
 
-            Assert.AreSame(textDef, s2.DefRef);
-            Assert.AreEqual("x", s2.CollectValue());
+            Assert.That(s2.DefRef, Is.SameAs(textDef));
+            Assert.That(s2.CollectValue(), Is.EqualTo("x"));
         }
 
         [Ignore("Will not fix")]
@@ -851,7 +882,7 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(1));
         }
 
         [Test]
@@ -875,21 +906,21 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
             // assertions
             Assert.IsEmpty(errors);
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(1));
             var s = spans[0];
-            Assert.AreSame(itemDef, s.DefRef);
-            Assert.AreEqual(4, s.Subspans.Count);
-            Assert.AreSame(itemDef.Nodes[0], s.Subspans[0].Node);
-            Assert.AreEqual("i", s.Subspans[0].Value);
+            Assert.That(s.DefRef, Is.SameAs(itemDef));
+            Assert.That(s.Subspans.Count, Is.EqualTo(4));
+            Assert.That(s.Subspans[0].Node, Is.SameAs(itemDef.Nodes[0]));
+            Assert.That(s.Subspans[0].Value, Is.EqualTo("i"));
             Assert.IsEmpty(s.Subspans[0].Subspans);
-            Assert.AreSame(itemDef.Nodes[1], s.Subspans[1].Node);
-            Assert.AreEqual("T", s.Subspans[1].Value);
+            Assert.That(s.Subspans[1].Node, Is.SameAs(itemDef.Nodes[1]));
+            Assert.That(s.Subspans[1].Value, Is.EqualTo("T"));
             Assert.IsEmpty(s.Subspans[1].Subspans);
-            Assert.AreSame(itemDef.Nodes[2], s.Subspans[2].Node);
-            Assert.AreEqual("e", s.Subspans[2].Value);
+            Assert.That(s.Subspans[2].Node, Is.SameAs(itemDef.Nodes[2]));
+            Assert.That(s.Subspans[2].Value, Is.EqualTo("e"));
             Assert.IsEmpty(s.Subspans[2].Subspans);
-            Assert.AreSame(itemDef.Nodes[3], s.Subspans[3].Node);
-            Assert.AreEqual("M", s.Subspans[3].Value);
+            Assert.That(s.Subspans[3].Node, Is.SameAs(itemDef.Nodes[3]));
+            Assert.That(s.Subspans[3].Value, Is.EqualTo("M"));
             Assert.IsEmpty(s.Subspans[3].Subspans);
         }
 
@@ -911,14 +942,16 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
             var spans = spanner.Process(input.ToCharacterSource(), errors);
 
             // assertions
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var e = (ParserError<InputChar>)(errors[0]);
-            Assert.AreEqual(ParserError.InvalidInputElement, e.ErrorType);
-            Assert.AreEqual('T', e.OffendingInputElement.Value);
-            Assert.AreEqual(new InputPosition(1, 1, 2), e.Position);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(e.OffendingInputElement.Value, Is.EqualTo('T'));
+            Assert.That(e.Position,
+                Is.EqualTo(new InputPosition(1, 1, 2)));
             Assert.IsNotNull(spans);
-            Assert.AreEqual(0, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(0));
         }
 
         [Test]
@@ -943,12 +976,12 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(errors);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(def, spans[0].DefRef);
-            Assert.AreEqual(1, spans[0].Subspans.Count);
-            Assert.AreSame(def.Nodes[0], spans[0].Subspans[0].Node);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(def));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(1));
+            Assert.That(spans[0].Subspans[0].Node, Is.SameAs(def.Nodes[0]));
             Assert.IsEmpty(spans[0].Subspans[0].Subspans);
-            Assert.AreEqual("a", spans[0].Subspans[0].Value);
+            Assert.That(spans[0].Subspans[0].Value, Is.EqualTo("a"));
         }
 
         [Test]
@@ -981,16 +1014,16 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(errors);
-            Assert.AreEqual(1, spans.Length);
+            Assert.That(spans.Length, Is.EqualTo(1));
             var s = spans[0];
-            Assert.AreSame(defdef, s.DefRef);
-            Assert.AreEqual(1, s.Subspans.Count);
+            Assert.That(s.DefRef, Is.SameAs(defdef));
+            Assert.That(s.Subspans.Count, Is.EqualTo(1));
             var s2 = s.Subspans[0];
-            Assert.AreSame(chardef, s2.DefRef);
-            Assert.AreEqual(1, s2.Subspans.Count);
+            Assert.That(s2.DefRef, Is.SameAs(chardef));
+            Assert.That(s2.Subspans.Count, Is.EqualTo(1));
             var s3 = s2.Subspans[0];
-            Assert.AreSame(chardef.Nodes[0], s3.Node);
-            Assert.AreEqual("a", s3.Value);
+            Assert.That(s3.Node, Is.SameAs(chardef.Nodes[0]));
+            Assert.That(s3.Value, Is.EqualTo("a"));
             Assert.IsEmpty(s3.Subspans);
         }
     }

--- a/MetaphysicsIndustries.Giza.Test/SpannerTests/MindWhitespaceOff.cs
+++ b/MetaphysicsIndustries.Giza.Test/SpannerTests/MindWhitespaceOff.cs
@@ -60,8 +60,8 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(errors);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreEqual("abc", spans[0].CollectValue());
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].CollectValue(), Is.EqualTo("abc"));
         }
 
         [Test]
@@ -72,8 +72,8 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(errors);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreEqual("abc", spans[0].CollectValue());
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].CollectValue(), Is.EqualTo("abc"));
         }
 
         [Test]
@@ -84,8 +84,8 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(errors);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreEqual("abc", spans[0].CollectValue());
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].CollectValue(), Is.EqualTo("abc"));
         }
 
         [Test]
@@ -96,8 +96,8 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(errors);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreEqual("abc", spans[0].CollectValue());
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].CollectValue(), Is.EqualTo("abc"));
         }
 
         [Test]
@@ -108,8 +108,8 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(errors);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreEqual("abc", spans[0].CollectValue());
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].CollectValue(), Is.EqualTo("abc"));
         }
 
         [Test]
@@ -120,8 +120,8 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(errors);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreEqual("abc", spans[0].CollectValue());
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].CollectValue(), Is.EqualTo("abc"));
         }
 
         [Test]
@@ -132,8 +132,8 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(errors);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreEqual("abc", spans[0].CollectValue());
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].CollectValue(), Is.EqualTo("abc"));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/SpannerTests/MindWhitespaceOn.cs
+++ b/MetaphysicsIndustries.Giza.Test/SpannerTests/MindWhitespaceOn.cs
@@ -61,8 +61,8 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(errors);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreEqual("abc", spans[0].CollectValue());
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].CollectValue(), Is.EqualTo("abc"));
         }
 
         [Test]
@@ -73,12 +73,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var e = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.InvalidInputElement, e.ErrorType);
-            Assert.AreEqual(new InputPosition(0, 1, 1), e.Position);
-            Assert.AreEqual(' ', e.OffendingInputElement.Value);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(e.Position,
+                Is.EqualTo(new InputPosition(0, 1, 1)));
+            Assert.That(e.OffendingInputElement.Value, Is.EqualTo(' '));
         }
 
         [Test]
@@ -89,12 +91,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var e = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.ExcessRemainingInput, e.ErrorType);
-            Assert.AreEqual(new InputPosition(3, 1, 4), e.Position);
-            Assert.AreEqual(' ', e.OffendingInputElement.Value);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ParserError.ExcessRemainingInput));
+            Assert.That(e.Position,
+                Is.EqualTo(new InputPosition(3, 1, 4)));
+            Assert.That(e.OffendingInputElement.Value, Is.EqualTo(' '));
         }
 
         [Test]
@@ -105,12 +109,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var e = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.InvalidInputElement, e.ErrorType);
-            Assert.AreEqual(new InputPosition(1, 1, 2), e.Position);
-            Assert.AreEqual(' ', e.OffendingInputElement.Value);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(e.Position,
+                Is.EqualTo(new InputPosition(1, 1, 2)));
+            Assert.That(e.OffendingInputElement.Value, Is.EqualTo(' '));
         }
 
         [Test]
@@ -121,12 +127,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var e = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.InvalidInputElement, e.ErrorType);
-            Assert.AreEqual(new InputPosition(0, 1, 1), e.Position);
-            Assert.AreEqual('\t', e.OffendingInputElement.Value);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(e.Position,
+                Is.EqualTo(new InputPosition(0, 1, 1)));
+            Assert.That(e.OffendingInputElement.Value, Is.EqualTo('\t'));
         }
 
         [Test]
@@ -137,12 +145,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var e = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.InvalidInputElement, e.ErrorType);
-            Assert.AreEqual(new InputPosition(0, 1, 1), e.Position);
-            Assert.AreEqual('\n', e.OffendingInputElement.Value);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(e.Position,
+                Is.EqualTo(new InputPosition(0, 1, 1)));
+            Assert.That(e.OffendingInputElement.Value, Is.EqualTo('\n'));
         }
 
         [Test]
@@ -153,12 +163,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var e = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.InvalidInputElement, e.ErrorType);
-            Assert.AreEqual(new InputPosition(0, 1, 1), e.Position);
-            Assert.AreEqual('\r', e.OffendingInputElement.Value);
+            Assert.That(e.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(e.Position,
+                Is.EqualTo(new InputPosition(0, 1, 1)));
+            Assert.That(e.OffendingInputElement.Value, Is.EqualTo('\r'));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/SpannerTests/SequenceTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/SpannerTests/SequenceTest.cs
@@ -59,15 +59,18 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
             // assertions
             Assert.IsEmpty(errors);
             Assert.IsNotNull(spans);
-            Assert.AreEqual(1, spans.Length);
-            Assert.AreSame(sequenceDef, spans[0].DefRef);
-            Assert.AreEqual(3, spans[0].Subspans.Count);
-            Assert.AreSame(sequenceDef.Nodes[0], spans[0].Subspans[0].Node);
-            Assert.AreSame(sequenceDef.Nodes[1], spans[0].Subspans[1].Node);
-            Assert.AreSame(sequenceDef.Nodes[2], spans[0].Subspans[2].Node);
-            Assert.AreEqual("a", spans[0].Subspans[0].Value);
-            Assert.AreEqual("b", spans[0].Subspans[1].Value);
-            Assert.AreEqual("c", spans[0].Subspans[2].Value);
+            Assert.That(spans.Length, Is.EqualTo(1));
+            Assert.That(spans[0].DefRef, Is.SameAs(sequenceDef));
+            Assert.That(spans[0].Subspans.Count, Is.EqualTo(3));
+            Assert.That(spans[0].Subspans[0].Node,
+                Is.SameAs(sequenceDef.Nodes[0]));
+            Assert.That(spans[0].Subspans[1].Node,
+                Is.SameAs(sequenceDef.Nodes[1]));
+            Assert.That(spans[0].Subspans[2].Node,
+                Is.SameAs(sequenceDef.Nodes[2]));
+            Assert.That(spans[0].Subspans[0].Value, Is.EqualTo("a"));
+            Assert.That(spans[0].Subspans[1].Value, Is.EqualTo("b"));
+            Assert.That(spans[0].Subspans[2].Value, Is.EqualTo("c"));
             Assert.IsEmpty(spans[0].Subspans[0].Subspans);
             Assert.IsEmpty(spans[0].Subspans[1].Subspans);
             Assert.IsEmpty(spans[0].Subspans[2].Subspans);
@@ -81,12 +84,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var se = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.ExcessRemainingInput, se.ErrorType);
-            Assert.AreEqual('d', se.OffendingInputElement.Value);
-            Assert.AreEqual(new InputPosition(3, 1, 4), se.Position);
+            Assert.That(se.ErrorType,
+                Is.EqualTo(ParserError.ExcessRemainingInput));
+            Assert.That(se.OffendingInputElement.Value, Is.EqualTo('d'));
+            Assert.That(se.Position,
+                Is.EqualTo(new InputPosition(3, 1, 4)));
         }
 
         [Test]
@@ -97,12 +102,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var se = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.InvalidInputElement, se.ErrorType);
-            Assert.AreEqual('c', se.OffendingInputElement.Value);
-            Assert.AreEqual(new InputPosition(1, 1, 2), se.Position);
+            Assert.That(se.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(se.OffendingInputElement.Value, Is.EqualTo('c'));
+            Assert.That(se.Position,
+                Is.EqualTo(new InputPosition(1, 1, 2)));
         }
 
         [Test]
@@ -113,12 +120,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var se = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.InvalidInputElement, se.ErrorType);
-            Assert.AreEqual('d', se.OffendingInputElement.Value);
-            Assert.AreEqual(new InputPosition(2, 1, 3), se.Position);
+            Assert.That(se.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(se.OffendingInputElement.Value, Is.EqualTo('d'));
+            Assert.That(se.Position,
+                Is.EqualTo(new InputPosition(2, 1, 3)));
         }
 
         [Test]
@@ -129,12 +138,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var se = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.InvalidInputElement, se.ErrorType);
-            Assert.AreEqual('b', se.OffendingInputElement.Value);
-            Assert.AreEqual(new InputPosition(2, 1, 3), se.Position);
+            Assert.That(se.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(se.OffendingInputElement.Value, Is.EqualTo('b'));
+            Assert.That(se.Position,
+                Is.EqualTo(new InputPosition(2, 1, 3)));
         }
 
         [Test]
@@ -145,12 +156,14 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError<InputChar>>(errors[0]);
             var se = (ParserError<InputChar>)errors[0];
-            Assert.AreEqual(ParserError.InvalidInputElement, se.ErrorType);
-            Assert.AreEqual('b', se.OffendingInputElement.Value);
-            Assert.AreEqual(new InputPosition(0, 1, 1), se.Position);
+            Assert.That(se.ErrorType,
+                Is.EqualTo(ParserError.InvalidInputElement));
+            Assert.That(se.OffendingInputElement.Value, Is.EqualTo('b'));
+            Assert.That(se.Position,
+                Is.EqualTo(new InputPosition(0, 1, 1)));
         }
 
         [Test]
@@ -161,11 +174,13 @@ namespace MetaphysicsIndustries.Giza.Test.SpannerTests
 
             // assertions
             Assert.IsEmpty(spans);
-            Assert.AreEqual(1, errors.Count);
+            Assert.That(errors.Count, Is.EqualTo(1));
             Assert.IsInstanceOf<ParserError>(errors[0]);
             var se = (ParserError)errors[0];
-            Assert.AreEqual(ParserError.UnexpectedEndOfInput, se.ErrorType);
-            Assert.AreEqual(new InputPosition(2, 1, 3), se.Position);
+            Assert.That(se.ErrorType,
+                Is.EqualTo(ParserError.UnexpectedEndOfInput));
+            Assert.That(se.Position,
+                Is.EqualTo(new InputPosition(2, 1, 3)));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/StringFormatterTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/StringFormatterTest.cs
@@ -38,7 +38,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, emptyParams);
 
             // assertions
-            Assert.AreEqual(format, result);
+            Assert.That(result, Is.EqualTo(format));
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("single result", result);
+            Assert.That(result, Is.EqualTo("single result"));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("single result", result);
+            Assert.That(result, Is.EqualTo("single result"));
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("single result", result);
+            Assert.That(result, Is.EqualTo("single result"));
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("single result", result);
+            Assert.That(result, Is.EqualTo("single result"));
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("first second", result);
+            Assert.That(result, Is.EqualTo("first second"));
         }
 
         [Test]
@@ -127,7 +127,8 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("a friend in need is a friend indeed", result);
+            Assert.That(result,
+                Is.EqualTo("a friend in need is a friend indeed"));
         }
 
         [Test]
@@ -140,7 +141,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, emptyParams);
 
             // assertions
-            Assert.AreEqual(format, result);
+            Assert.That(result, Is.EqualTo(format));
         }
 
         [Test]
@@ -153,7 +154,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, emptyParams);
 
             // assertions
-            Assert.AreEqual(format, result);
+            Assert.That(result, Is.EqualTo(format));
         }
 
         [Test]
@@ -166,7 +167,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, emptyParams);
 
             // assertions
-            Assert.AreEqual(format, result);
+            Assert.That(result, Is.EqualTo(format));
         }
 
         [Test]
@@ -179,7 +180,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, emptyParams);
 
             // assertions
-            Assert.AreEqual(format, result);
+            Assert.That(result, Is.EqualTo(format));
         }
 
         [Test]
@@ -196,7 +197,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("more widgets than params", result);
+            Assert.That(result, Is.EqualTo("more widgets than params"));
         }
 
         [Test]
@@ -212,7 +213,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("more {params} than widgets", result);
+            Assert.That(result, Is.EqualTo("more {params} than widgets"));
         }
 
         [Test]
@@ -225,7 +226,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, emptyParams);
 
             // assertions
-            Assert.AreEqual("escape {", result);
+            Assert.That(result, Is.EqualTo("escape {"));
         }
 
         [Test]
@@ -238,7 +239,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, emptyParams);
 
             // assertions
-            Assert.AreEqual("escape }", result);
+            Assert.That(result, Is.EqualTo("escape }"));
         }
 
         [Test]
@@ -251,7 +252,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, emptyParams);
 
             // assertions
-            Assert.AreEqual("escapes {text}", result);
+            Assert.That(result, Is.EqualTo("escapes {text}"));
         }
 
         [Test]
@@ -267,7 +268,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("difficult {something}", result);
+            Assert.That(result, Is.EqualTo("difficult {something}"));
         }
 
         [Test]
@@ -280,7 +281,8 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, emptyParams);
 
             // assertions
-            Assert.AreEqual("difficult {{escape}} with missing param", result);
+            Assert.That(result,
+                Is.EqualTo("difficult {{escape}} with missing param"));
         }
 
         [Test]
@@ -294,7 +296,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("func arg", result);
+            Assert.That(result, Is.EqualTo("func arg"));
         }
 
         [Test]
@@ -308,7 +310,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("func arg and object", result);
+            Assert.That(result, Is.EqualTo("func arg and object"));
         }
 
         [Test]
@@ -324,7 +326,8 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("one arg two object three {another}", result);
+            Assert.That(result,
+                Is.EqualTo("one arg two object three {another}"));
         }
 
         [Test]
@@ -338,7 +341,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("func arg arg arg", result);
+            Assert.That(result, Is.EqualTo("func arg arg arg"));
         }
 
         [Test]
@@ -355,7 +358,7 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = StringFormatter.Format(format, values);
 
             // assertions
-            Assert.AreEqual("func arg arg arg", result);
+            Assert.That(result, Is.EqualTo("func arg arg arg"));
         }
 
         [Test]
@@ -371,7 +374,8 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = "one {param} two {something} three {another}".Format(values);
 
             // assertions
-            Assert.AreEqual("one arg two object three {another}", result);
+            Assert.That(result,
+                Is.EqualTo("one arg two object three {another}"));
         }
 
         [Test]
@@ -386,7 +390,8 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = "one {param} two {something} three {another}".Format(values);
 
             // assertions
-            Assert.AreEqual("one arg two object three {another}", result);
+            Assert.That(result,
+                Is.EqualTo("one arg two object three {another}"));
         }
 
         [Test]

--- a/MetaphysicsIndustries.Giza.Test/SupergrammarSpannerTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/SupergrammarSpannerTest.cs
@@ -36,10 +36,10 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = ss.GetGrammar(input, errors, source);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(source, result.Source);
-            Assert.AreEqual(1, result.Definitions.Count);
-            Assert.AreEqual("def1", result.Definitions[0].Name);
-            Assert.AreEqual(source, result.Definitions[0].Source);
+            Assert.That(result.Source, Is.EqualTo(source));
+            Assert.That(result.Definitions.Count, Is.EqualTo(1));
+            Assert.That(result.Definitions[0].Name, Is.EqualTo("def1"));
+            Assert.That(result.Definitions[0].Source, Is.EqualTo(source));
         }
     }
 }

--- a/MetaphysicsIndustries.Giza.Test/TokenizeTransformTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/TokenizeTransformTest.cs
@@ -51,24 +51,24 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(2, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(2));
 
             Assert.IsNotNull(explicitDef);
-            Assert.AreEqual(0, explicitDef.Directives.Count);
+            Assert.That(explicitDef.Directives.Count, Is.EqualTo(0));
             Assert.IsFalse(explicitDef.Atomic);
             Assert.IsFalse(explicitDef.IgnoreCase);
             Assert.IsFalse(explicitDef.IsComment);
             Assert.IsFalse(explicitDef.IsTokenized);
             Assert.IsFalse(explicitDef.MindWhitespace);
             Assert.IsNotNull(explicitDef.Expr.Items);
-            Assert.AreEqual(1, explicitDef.Expr.Items.Count);
+            Assert.That(explicitDef.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(explicitDef.Expr.Items[0]);
             Assert.IsInstanceOf<DefRefSubExpression>(explicitDef.Expr.Items[0]);
             var defref = (DefRefSubExpression) explicitDef.Expr.Items[0];
-            Assert.AreEqual(implicitDef.Name, defref.DefinitionName);
+            Assert.That(defref.DefinitionName, Is.EqualTo(implicitDef.Name));
 
             Assert.IsNotNull(implicitDef);
-            Assert.AreEqual(3, implicitDef.Directives.Count);
+            Assert.That(implicitDef.Directives.Count, Is.EqualTo(3));
             Assert.Contains(DefinitionDirective.Token, implicitDef.Directives.ToArray());
             Assert.Contains(DefinitionDirective.Atomic, implicitDef.Directives.ToArray());
             Assert.Contains(DefinitionDirective.MindWhitespace, implicitDef.Directives.ToArray());
@@ -78,12 +78,12 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(implicitDef.IsTokenized);
             Assert.IsTrue(implicitDef.MindWhitespace);
             Assert.IsNotNull(implicitDef.Expr.Items);
-            Assert.AreEqual(1, implicitDef.Expr.Items.Count);
+            Assert.That(implicitDef.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(implicitDef.Expr.Items[0]);
             Assert.IsInstanceOf<LiteralSubExpression>(implicitDef.Expr.Items[0]);
             var literal = (LiteralSubExpression) implicitDef.Expr.Items[0];
-            Assert.AreEqual("value", literal.Value);
-            Assert.AreEqual("",literal.Tag);
+            Assert.That(literal.Value, Is.EqualTo("value"));
+            Assert.That(literal.Tag, Is.EqualTo(""));
             Assert.IsFalse(literal.IsSkippable);
             Assert.IsFalse(literal.IsRepeatable);
         }
@@ -112,24 +112,24 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(2, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(2));
 
             Assert.IsNotNull(explicitDef);
-            Assert.AreEqual(0, explicitDef.Directives.Count);
+            Assert.That(explicitDef.Directives.Count, Is.EqualTo(0));
             Assert.IsFalse(explicitDef.Atomic);
             Assert.IsFalse(explicitDef.IgnoreCase);
             Assert.IsFalse(explicitDef.IsComment);
             Assert.IsFalse(explicitDef.IsTokenized);
             Assert.IsFalse(explicitDef.MindWhitespace);
             Assert.IsNotNull(explicitDef.Expr.Items);
-            Assert.AreEqual(1, explicitDef.Expr.Items.Count);
+            Assert.That(explicitDef.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(explicitDef.Expr.Items[0]);
             Assert.IsInstanceOf<DefRefSubExpression>(explicitDef.Expr.Items[0]);
             var defref = (DefRefSubExpression) explicitDef.Expr.Items[0];
-            Assert.AreEqual(implicitDef.Name, defref.DefinitionName);
+            Assert.That(defref.DefinitionName, Is.EqualTo(implicitDef.Name));
 
             Assert.IsNotNull(implicitDef);
-            Assert.AreEqual(3, implicitDef.Directives.Count);
+            Assert.That(implicitDef.Directives.Count, Is.EqualTo(3));
             Assert.Contains(DefinitionDirective.Token, implicitDef.Directives.ToArray());
             Assert.Contains(DefinitionDirective.Atomic, implicitDef.Directives.ToArray());
             Assert.Contains(DefinitionDirective.MindWhitespace, implicitDef.Directives.ToArray());
@@ -139,12 +139,12 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(implicitDef.IsTokenized);
             Assert.IsTrue(implicitDef.MindWhitespace);
             Assert.IsNotNull(implicitDef.Expr.Items);
-            Assert.AreEqual(1, implicitDef.Expr.Items.Count);
+            Assert.That(implicitDef.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(implicitDef.Expr.Items[0]);
             Assert.IsInstanceOf<CharClassSubExpression>(implicitDef.Expr.Items[0]);
             var cc = (CharClassSubExpression) implicitDef.Expr.Items[0];
-            Assert.AreEqual("\\d", cc.CharClass.ToUndelimitedString());
-            Assert.AreEqual("",cc.Tag);
+            Assert.That(cc.CharClass.ToUndelimitedString(), Is.EqualTo("\\d"));
+            Assert.That(cc.Tag, Is.EqualTo(""));
             Assert.IsFalse(cc.IsSkippable);
             Assert.IsFalse(cc.IsRepeatable);
         }
@@ -176,40 +176,44 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(2, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(2));
 
             Assert.IsNotNull(explicitDef);
-            Assert.AreEqual(0, explicitDef.Directives.Count);
+            Assert.That(explicitDef.Directives.Count, Is.EqualTo(0));
             Assert.IsFalse(explicitDef.Atomic);
             Assert.IsFalse(explicitDef.IgnoreCase);
             Assert.IsFalse(explicitDef.IsComment);
             Assert.IsFalse(explicitDef.IsTokenized);
             Assert.IsFalse(explicitDef.MindWhitespace);
             Assert.IsNotNull(explicitDef.Expr.Items);
-            Assert.AreEqual(1, explicitDef.Expr.Items.Count);
+            Assert.That(explicitDef.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(explicitDef.Expr.Items[0]);
             Assert.IsInstanceOf<DefRefSubExpression>(explicitDef.Expr.Items[0]);
             var defref = (DefRefSubExpression) explicitDef.Expr.Items[0];
-            Assert.AreEqual(implicitDef.Name, defref.DefinitionName);
+            Assert.That(defref.DefinitionName, Is.EqualTo(implicitDef.Name));
 
             Assert.IsNotNull(implicitDef);
-            Assert.AreEqual(4, implicitDef.Directives.Count);
-            Assert.Contains(DefinitionDirective.Token, implicitDef.Directives.ToArray());
-            Assert.Contains(DefinitionDirective.Atomic, implicitDef.Directives.ToArray());
-            Assert.Contains(DefinitionDirective.IgnoreCase, implicitDef.Directives.ToArray());
-            Assert.Contains(DefinitionDirective.MindWhitespace, implicitDef.Directives.ToArray());
+            Assert.That(implicitDef.Directives.Count, Is.EqualTo(4));
+            Assert.That(implicitDef.Directives.ToArray(),
+                Does.Contain(DefinitionDirective.Token));
+            Assert.That(implicitDef.Directives.ToArray(),
+                Does.Contain(DefinitionDirective.Atomic));
+            Assert.That(implicitDef.Directives.ToArray(),
+                Does.Contain(DefinitionDirective.IgnoreCase));
+            Assert.That(implicitDef.Directives.ToArray(),
+                Does.Contain(DefinitionDirective.MindWhitespace));
             Assert.IsTrue(implicitDef.Atomic);
             Assert.IsTrue(implicitDef.IgnoreCase);
             Assert.IsFalse(implicitDef.IsComment);
             Assert.IsTrue(implicitDef.IsTokenized);
             Assert.IsTrue(implicitDef.MindWhitespace);
             Assert.IsNotNull(implicitDef.Expr.Items);
-            Assert.AreEqual(1, implicitDef.Expr.Items.Count);
+            Assert.That(implicitDef.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(implicitDef.Expr.Items[0]);
             Assert.IsInstanceOf<LiteralSubExpression>(implicitDef.Expr.Items[0]);
             var literal = (LiteralSubExpression) implicitDef.Expr.Items[0];
-            Assert.AreEqual("value", literal.Value);
-            Assert.AreEqual("",literal.Tag);
+            Assert.That(literal.Value, Is.EqualTo("value"));
+            Assert.That(literal.Tag, Is.EqualTo(""));
             Assert.IsFalse(literal.IsSkippable);
             Assert.IsFalse(literal.IsRepeatable);
         }
@@ -243,10 +247,10 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(2, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(2));
 
             Assert.IsNotNull(explicitDef);
-            Assert.AreEqual(0, explicitDef.Directives.Count);
+            Assert.That(explicitDef.Directives.Count, Is.EqualTo(0));
             Assert.IsFalse(explicitDef.Atomic);
             Assert.IsFalse(explicitDef.IgnoreCase);
             Assert.IsFalse(explicitDef.IsComment);
@@ -254,7 +258,7 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsFalse(explicitDef.MindWhitespace);
 
             Assert.IsNotNull(implicitDef);
-            Assert.AreEqual(4, implicitDef.Directives.Count);
+            Assert.That(implicitDef.Directives.Count, Is.EqualTo(4));
             Assert.Contains(DefinitionDirective.Token, implicitDef.Directives.ToArray());
             Assert.Contains(DefinitionDirective.Atomic, implicitDef.Directives.ToArray());
             Assert.Contains(DefinitionDirective.IgnoreCase, implicitDef.Directives.ToArray());
@@ -265,12 +269,12 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(implicitDef.IsTokenized);
             Assert.IsTrue(implicitDef.MindWhitespace);
             Assert.IsNotNull(implicitDef.Expr.Items);
-            Assert.AreEqual(1, implicitDef.Expr.Items.Count);
+            Assert.That(implicitDef.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(implicitDef.Expr.Items[0]);
             Assert.IsInstanceOf<CharClassSubExpression>(implicitDef.Expr.Items[0]);
             var cc = (CharClassSubExpression) implicitDef.Expr.Items[0];
-            Assert.AreEqual("\\d", cc.CharClass.ToUndelimitedString());
-            Assert.AreEqual("",cc.Tag);
+            Assert.That(cc.CharClass.ToUndelimitedString(), Is.EqualTo("\\d"));
+            Assert.That(cc.Tag, Is.EqualTo(""));
             Assert.IsFalse(cc.IsSkippable);
             Assert.IsFalse(cc.IsRepeatable);
         }
@@ -306,21 +310,21 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(2, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(2));
 
             Assert.IsNotNull(def);
-            Assert.AreEqual(0, def.Directives.Count);
+            Assert.That(def.Directives.Count, Is.EqualTo(0));
             Assert.IsFalse(def.Atomic);
             Assert.IsFalse(def.IgnoreCase);
             Assert.IsFalse(def.IsComment);
             Assert.IsFalse(def.IsTokenized);
             Assert.IsFalse(def.MindWhitespace);
             Assert.IsNotNull(def.Expr.Items);
-            Assert.AreEqual(1, def.Expr.Items.Count);
+            Assert.That(def.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(def.Expr.Items[0]);
             Assert.IsInstanceOf<DefRefSubExpression>(def.Expr.Items[0]);
             var defref = (DefRefSubExpression) def.Expr.Items[0];
-            Assert.AreEqual("token", defref.DefinitionName);
+            Assert.That(defref.DefinitionName, Is.EqualTo("token"));
         }
 
         [Test]
@@ -348,10 +352,10 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(1, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(1));
 
             Assert.IsNotNull(def);
-            Assert.AreEqual(3, def.Directives.Count);
+            Assert.That(def.Directives.Count, Is.EqualTo(3));
             Assert.Contains(DefinitionDirective.Token, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.Atomic, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.MindWhitespace, def.Directives.ToArray());
@@ -361,12 +365,12 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(def.IsTokenized);
             Assert.IsTrue(def.MindWhitespace);
             Assert.IsNotNull(def.Expr.Items);
-            Assert.AreEqual(1, def.Expr.Items.Count);
+            Assert.That(def.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(def.Expr.Items[0]);
             Assert.IsInstanceOf<LiteralSubExpression>(def.Expr.Items[0]);
             var literal = (LiteralSubExpression) def.Expr.Items[0];
-            Assert.AreEqual("value", literal.Value);
-            Assert.AreEqual("",literal.Tag);
+            Assert.That(literal.Value, Is.EqualTo("value"));
+            Assert.That(literal.Tag, Is.EqualTo(""));
             Assert.IsFalse(literal.IsSkippable);
             Assert.IsFalse(literal.IsRepeatable);
         }
@@ -398,10 +402,10 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(1, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(1));
 
             Assert.IsNotNull(def);
-            Assert.AreEqual(2, def.Directives.Count);
+            Assert.That(def.Directives.Count, Is.EqualTo(2));
             Assert.Contains(DefinitionDirective.Subtoken, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.MindWhitespace, def.Directives.ToArray());
             Assert.IsFalse(def.Atomic);
@@ -410,12 +414,12 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(def.IsTokenized);
             Assert.IsTrue(def.MindWhitespace);
             Assert.IsNotNull(def.Expr.Items);
-            Assert.AreEqual(1, def.Expr.Items.Count);
+            Assert.That(def.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(def.Expr.Items[0]);
             Assert.IsInstanceOf<LiteralSubExpression>(def.Expr.Items[0]);
             var literal = (LiteralSubExpression) def.Expr.Items[0];
-            Assert.AreEqual("value", literal.Value);
-            Assert.AreEqual("",literal.Tag);
+            Assert.That(literal.Value, Is.EqualTo("value"));
+            Assert.That(literal.Tag, Is.EqualTo(""));
             Assert.IsFalse(literal.IsSkippable);
             Assert.IsFalse(literal.IsRepeatable);
         }
@@ -446,10 +450,10 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(1, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(1));
 
             Assert.IsNotNull(def);
-            Assert.AreEqual(3, def.Directives.Count);
+            Assert.That(def.Directives.Count, Is.EqualTo(3));
             Assert.Contains(DefinitionDirective.Comment, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.Atomic, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.MindWhitespace, def.Directives.ToArray());
@@ -459,12 +463,12 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(def.IsTokenized);
             Assert.IsTrue(def.MindWhitespace);
             Assert.IsNotNull(def.Expr.Items);
-            Assert.AreEqual(1, def.Expr.Items.Count);
+            Assert.That(def.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(def.Expr.Items[0]);
             Assert.IsInstanceOf<LiteralSubExpression>(def.Expr.Items[0]);
             var literal = (LiteralSubExpression) def.Expr.Items[0];
-            Assert.AreEqual("value", literal.Value);
-            Assert.AreEqual("",literal.Tag);
+            Assert.That(literal.Value, Is.EqualTo("value"));
+            Assert.That(literal.Tag, Is.EqualTo(""));
             Assert.IsFalse(literal.IsSkippable);
             Assert.IsFalse(literal.IsRepeatable);
         }
@@ -503,22 +507,22 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(2, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(2));
 
             Assert.IsNotNull(def);
-            Assert.AreEqual(0, def.Directives.Count);
+            Assert.That(def.Directives.Count, Is.EqualTo(0));
             Assert.IsFalse(def.Atomic);
             Assert.IsFalse(def.IgnoreCase);
             Assert.IsFalse(def.IsComment);
             Assert.IsFalse(def.IsTokenized);
             Assert.IsFalse(def.MindWhitespace);
             Assert.IsNotNull(def.Expr.Items);
-            Assert.AreEqual(1, def.Expr.Items.Count);
+            Assert.That(def.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(def.Expr.Items[0]);
             Assert.IsInstanceOf<DefRefSubExpression>(def.Expr.Items[0]);
             var defref = (DefRefSubExpression) def.Expr.Items[0];
-            Assert.AreEqual("token", defref.DefinitionName);
-            Assert.AreEqual("",defref.Tag);
+            Assert.That(defref.DefinitionName, Is.EqualTo("token"));
+            Assert.That(defref.Tag, Is.EqualTo(""));
             Assert.IsFalse(defref.IsSkippable);
             Assert.IsFalse(defref.IsRepeatable);
         }
@@ -551,10 +555,10 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(1, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(1));
 
             Assert.IsNotNull(def);
-            Assert.AreEqual(3, def.Directives.Count);
+            Assert.That(def.Directives.Count, Is.EqualTo(3));
             Assert.Contains(DefinitionDirective.Token, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.Atomic, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.MindWhitespace, def.Directives.ToArray());
@@ -564,12 +568,12 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(def.IsTokenized);
             Assert.IsTrue(def.MindWhitespace);
             Assert.IsNotNull(def.Expr.Items);
-            Assert.AreEqual(1, def.Expr.Items.Count);
+            Assert.That(def.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(def.Expr.Items[0]);
             Assert.IsInstanceOf<LiteralSubExpression>(def.Expr.Items[0]);
             var literal = (LiteralSubExpression) def.Expr.Items[0];
-            Assert.AreEqual("value", literal.Value);
-            Assert.AreEqual("",literal.Tag);
+            Assert.That(literal.Value, Is.EqualTo("value"));
+            Assert.That(literal.Tag, Is.EqualTo(""));
             Assert.IsFalse(literal.IsSkippable);
             Assert.IsFalse(literal.IsRepeatable);
         }
@@ -602,10 +606,10 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(1, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(1));
 
             Assert.IsNotNull(def);
-            Assert.AreEqual(3, def.Directives.Count);
+            Assert.That(def.Directives.Count, Is.EqualTo(3));
             Assert.Contains(DefinitionDirective.Subtoken, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.Atomic, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.MindWhitespace, def.Directives.ToArray());
@@ -615,12 +619,12 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(def.IsTokenized);
             Assert.IsTrue(def.MindWhitespace);
             Assert.IsNotNull(def.Expr.Items);
-            Assert.AreEqual(1, def.Expr.Items.Count);
+            Assert.That(def.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(def.Expr.Items[0]);
             Assert.IsInstanceOf<LiteralSubExpression>(def.Expr.Items[0]);
             var literal = (LiteralSubExpression) def.Expr.Items[0];
-            Assert.AreEqual("value", literal.Value);
-            Assert.AreEqual("",literal.Tag);
+            Assert.That(literal.Value, Is.EqualTo("value"));
+            Assert.That(literal.Tag, Is.EqualTo(""));
             Assert.IsFalse(literal.IsSkippable);
             Assert.IsFalse(literal.IsRepeatable);
         }
@@ -653,10 +657,10 @@ namespace MetaphysicsIndustries.Giza.Test
 
             // assertions
             Assert.IsNotNull(grammar);
-            Assert.AreEqual(1, grammar.Definitions.Count);
+            Assert.That(grammar.Definitions.Count, Is.EqualTo(1));
 
             Assert.IsNotNull(def);
-            Assert.AreEqual(3, def.Directives.Count);
+            Assert.That(def.Directives.Count, Is.EqualTo(3));
             Assert.Contains(DefinitionDirective.Comment, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.Atomic, def.Directives.ToArray());
             Assert.Contains(DefinitionDirective.MindWhitespace, def.Directives.ToArray());
@@ -666,12 +670,12 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(def.IsTokenized);
             Assert.IsTrue(def.MindWhitespace);
             Assert.IsNotNull(def.Expr.Items);
-            Assert.AreEqual(1, def.Expr.Items.Count);
+            Assert.That(def.Expr.Items.Count, Is.EqualTo(1));
             Assert.IsNotNull(def.Expr.Items[0]);
             Assert.IsInstanceOf<LiteralSubExpression>(def.Expr.Items[0]);
             var literal = (LiteralSubExpression) def.Expr.Items[0];
-            Assert.AreEqual("value", literal.Value);
-            Assert.AreEqual("",literal.Tag);
+            Assert.That(literal.Value, Is.EqualTo("value"));
+            Assert.That(literal.Tag, Is.EqualTo(""));
             Assert.IsFalse(literal.IsSkippable);
             Assert.IsFalse(literal.IsRepeatable);
         }
@@ -695,11 +699,11 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = tt.Tokenize(g);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Definitions.Count);
+            Assert.That(result.Definitions.Count, Is.EqualTo(2));
             var explicitDef = result.FindDefinitionByName("def");
             Assert.IsNotNull(explicitDef);
             Assert.IsTrue(explicitDef.IsImported); // still marked as imported
-            Assert.AreNotSame(explicitDef,g.Definitions[0]);
+            Assert.That(g.Definitions[0], Is.Not.SameAs(explicitDef));
             var implicitDef =
                 result.FindDefinitionByName("$implicit literal value");
             Assert.IsNotNull(implicitDef);
@@ -727,19 +731,19 @@ namespace MetaphysicsIndustries.Giza.Test
             var result = tt.Tokenize(g);
             // then
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Definitions.Count);
-            Assert.AreEqual("src1", result.Source);
+            Assert.That(result.Definitions.Count, Is.EqualTo(2));
+            Assert.That(result.Source, Is.EqualTo("src1"));
 
             var explicitDef = result.FindDefinitionByName("def");
             Assert.IsNotNull(explicitDef);
-            Assert.AreEqual("src1", explicitDef.Source); //
-            Assert.AreNotSame(explicitDef,g.Definitions[0]);
+            Assert.That(explicitDef.Source, Is.EqualTo("src1")); //
+            Assert.That(g.Definitions[0], Is.Not.SameAs(explicitDef));
 
             var implicitDef =
                 result.FindDefinitionByName("$implicit literal value");
             Assert.IsNotNull(implicitDef);
 
-            Assert.AreEqual("src1", implicitDef.Source);
+            Assert.That(implicitDef.Source, Is.EqualTo("src1"));
             // should it be, though?
         }
     }

--- a/MetaphysicsIndustries.Giza.Test/TokenizerTest.cs
+++ b/MetaphysicsIndustries.Giza.Test/TokenizerTest.cs
@@ -108,21 +108,21 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsEmpty(tinfo.Errors);
             Assert.IsFalse(tinfo.EndOfInput);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             var first = tinfo.InputElements.First();
-            Assert.AreEqual(item1Def, first.Definition);
-            Assert.AreEqual(0, first.StartPosition.Index);
-            Assert.AreEqual("item1", first.Value);
+            Assert.That(first.Definition, Is.EqualTo(item1Def));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(0));
+            Assert.That(first.Value, Is.EqualTo("item1"));
 
             tinfo = t.GetInputAtLocation(5);
 
             Assert.IsEmpty(tinfo.Errors);
             Assert.IsFalse(tinfo.EndOfInput);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             first = tinfo.InputElements.First();
-            Assert.AreEqual(item2Def, first.Definition);
-            Assert.AreEqual(6, first.StartPosition.Index);
-            Assert.AreEqual("item2", first.Value);
+            Assert.That(first.Definition, Is.EqualTo(item2Def));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(6));
+            Assert.That(first.Value, Is.EqualTo("item2"));
         }
 
         [Test()]
@@ -239,11 +239,11 @@ namespace MetaphysicsIndustries.Giza.Test
             //assertions
             Assert.IsEmpty(errors);
             Assert.IsFalse(tinfo.EndOfInput);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             var first = tinfo.InputElements.First();
-            Assert.AreEqual(varrefDef, first.Definition);
-            Assert.AreEqual(0, first.StartPosition.Index);
-            Assert.AreEqual("a", first.Value);
+            Assert.That(first.Definition, Is.EqualTo(varrefDef));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(0));
+            Assert.That(first.Value, Is.EqualTo("a"));
 
             // action
             tinfo = t.GetInputAtLocation(1);
@@ -251,7 +251,7 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsEmpty(errors);
             Assert.IsFalse(tinfo.EndOfInput);
-            Assert.AreEqual(2, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(2));
             first = tinfo.InputElements.First();
             var second = tinfo.InputElements.ElementAt(1);
             Assert.IsTrue(first.Definition == plusplusDef || first.Definition == operDef);
@@ -271,10 +271,10 @@ namespace MetaphysicsIndustries.Giza.Test
                 operToken = first;
             }
 
-            Assert.AreEqual(1, plusplusToken.StartPosition.Index);
-            Assert.AreEqual("++", plusplusToken.Value);
-            Assert.AreEqual(1, operToken.StartPosition.Index);
-            Assert.AreEqual("+", operToken.Value);
+            Assert.That(plusplusToken.StartPosition.Index, Is.EqualTo(1));
+            Assert.That(plusplusToken.Value, Is.EqualTo("++"));
+            Assert.That(operToken.StartPosition.Index, Is.EqualTo(1));
+            Assert.That(operToken.Value, Is.EqualTo("+"));
         }
 
         [Test()]
@@ -345,11 +345,11 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsEmpty(errors);
             Assert.IsFalse(tinfo.EndOfInput);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             var first = tinfo.InputElements.First();
-            Assert.AreEqual(itemDef, first.Definition);
-            Assert.AreEqual(0, first.StartPosition.Index);
-            Assert.AreEqual("a", first.Value);
+            Assert.That(first.Definition, Is.EqualTo(itemDef));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(0));
+            Assert.That(first.Value, Is.EqualTo("a"));
 
             // action
             tinfo = t.GetInputAtLocation(1);
@@ -357,13 +357,13 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsEmpty(errors);
             Assert.IsFalse(tinfo.EndOfInput);
-            Assert.AreEqual(2, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(2));
             first = tinfo.InputElements.First();
             var second = tinfo.InputElements.ElementAt(1);
-            Assert.AreEqual(2, first.StartPosition.Index);
-            Assert.AreEqual(2, second.StartPosition.Index);
-            Assert.AreEqual(operDef, first.Definition);
-            Assert.AreEqual(operDef, second.Definition);
+            Assert.That(first.StartPosition.Index, Is.EqualTo(2));
+            Assert.That(second.StartPosition.Index, Is.EqualTo(2));
+            Assert.That(first.Definition, Is.EqualTo(operDef));
+            Assert.That(second.Definition, Is.EqualTo(operDef));
             Assert.IsTrue(first.Value == "<" || first.Value == "<<");
             Assert.IsTrue(second.Value == "<" || second.Value == "<<");
             Assert.IsTrue(first.Value != second.Value);
@@ -439,12 +439,12 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsFalse(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             var first = tinfo.InputElements.First();
-            Assert.AreSame(operandDef, first.Definition);
-            Assert.AreEqual(0, first.StartPosition.Index);
-            Assert.AreEqual("a", first.Value);
-            Assert.AreEqual(-1, tinfo.EndOfInputPosition.Index);
+            Assert.That(first.Definition, Is.SameAs(operandDef));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(0));
+            Assert.That(first.Value, Is.EqualTo("a"));
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(-1));
         }
 
         [Test]
@@ -468,12 +468,12 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsFalse(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             var first = tinfo.InputElements.First();
-            Assert.AreSame(operatorDef, first.Definition);
-            Assert.AreEqual(2, first.StartPosition.Index);
-            Assert.AreEqual("+", first.Value);
-            Assert.AreEqual(-1, tinfo.EndOfInputPosition.Index);
+            Assert.That(first.Definition, Is.SameAs(operatorDef));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(2));
+            Assert.That(first.Value, Is.EqualTo("+"));
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(-1));
         }
 
         [Test]
@@ -497,12 +497,12 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsFalse(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             var first = tinfo.InputElements.First();
-            Assert.AreSame(operatorDef, first.Definition);
-            Assert.AreEqual(2, first.StartPosition.Index);
-            Assert.AreEqual("+", first.Value);
-            Assert.AreEqual(-1, tinfo.EndOfInputPosition.Index);
+            Assert.That(first.Definition, Is.SameAs(operatorDef));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(2));
+            Assert.That(first.Value, Is.EqualTo("+"));
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(-1));
         }
 
         [Test]
@@ -526,12 +526,12 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsFalse(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             var first = tinfo.InputElements.First();
-            Assert.AreSame(operandDef, first.Definition);
-            Assert.AreEqual(4, first.StartPosition.Index);
-            Assert.AreEqual("b", first.Value);
-            Assert.AreEqual(-1, tinfo.EndOfInputPosition.Index);
+            Assert.That(first.Definition, Is.SameAs(operandDef));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(4));
+            Assert.That(first.Value, Is.EqualTo("b"));
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(-1));
         }
 
         [Test]
@@ -555,12 +555,12 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsFalse(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             var first = tinfo.InputElements.First();
-            Assert.AreSame(operandDef, first.Definition);
-            Assert.AreEqual(4, first.StartPosition.Index);
-            Assert.AreEqual("b", first.Value);
-            Assert.AreEqual(-1, tinfo.EndOfInputPosition.Index);
+            Assert.That(first.Definition, Is.SameAs(operandDef));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(4));
+            Assert.That(first.Value, Is.EqualTo("b"));
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(-1));
         }
 
         [Test]
@@ -582,8 +582,8 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsTrue(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
-            Assert.AreEqual(0, tinfo.InputElements.Count());
-            Assert.AreEqual(5, tinfo.EndOfInputPosition.Index);
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(0));
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(5));
         }
 
         [Test]
@@ -605,7 +605,7 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
             Assert.IsEmpty(tinfo.InputElements);
-            Assert.AreEqual(5, tinfo.EndOfInputPosition.Index);
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(5));
         }
 
         [Test]
@@ -627,7 +627,7 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
             Assert.IsEmpty(tinfo.InputElements);
-            Assert.AreEqual(6, tinfo.EndOfInputPosition.Index);
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(6));
         }
 
         [Test]
@@ -649,7 +649,7 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
             Assert.IsEmpty(tinfo.InputElements);
-            Assert.AreEqual(6, tinfo.EndOfInputPosition.Index);
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(6));
         }
 
         static NGrammar CreateGrammarForTestEndOfInputParameterWithComment()
@@ -704,7 +704,7 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
             Assert.IsEmpty(tinfo.InputElements);
-            Assert.AreEqual(16, tinfo.EndOfInputPosition.Index);
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(16));
         }
 
         [Test]
@@ -727,7 +727,7 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
             Assert.IsEmpty(tinfo.InputElements);
-            Assert.AreEqual(17, tinfo.EndOfInputPosition.Index);
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(17));
         }
 
         [Test]
@@ -750,7 +750,7 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsTrue(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
             Assert.IsEmpty(tinfo.InputElements);
-            Assert.AreEqual(17, tinfo.EndOfInputPosition.Index);
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(17));
         }
 
         [Test]
@@ -792,12 +792,12 @@ namespace MetaphysicsIndustries.Giza.Test
             // assertions
             Assert.IsTrue(tinfo.EndOfInput);
             Assert.IsNotNull(tinfo.InputElements);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             var first = tinfo.InputElements.First();
-            Assert.AreSame(strangeDef, first.Definition);
-            Assert.AreEqual(5, first.StartPosition.Index);
-            Assert.AreEqual("/*comment", first.Value);
-            Assert.AreEqual(16, tinfo.EndOfInputPosition.Index);
+            Assert.That(first.Definition, Is.SameAs(strangeDef));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(5));
+            Assert.That(first.Value, Is.EqualTo("/*comment"));
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(16));
         }
 
         [Test]
@@ -881,13 +881,13 @@ namespace MetaphysicsIndustries.Giza.Test
 
 
             Assert.IsFalse(tinfo.EndOfInput);
-            Assert.AreEqual(-1, tinfo.EndOfInputPosition.Index);
+            Assert.That(tinfo.EndOfInputPosition.Index, Is.EqualTo(-1));
             Assert.IsNotNull(tinfo.InputElements);
-            Assert.AreEqual(1, tinfo.InputElements.Count());
+            Assert.That(tinfo.InputElements.Count(), Is.EqualTo(1));
             var first = tinfo.InputElements.First();
-            Assert.AreSame(itemDef, first.Definition);
-            Assert.AreEqual(0, first.StartPosition.Index);
-            Assert.AreEqual("start-ABCD-end", first.Value);
+            Assert.That(first.Definition, Is.SameAs(itemDef));
+            Assert.That(first.StartPosition.Index, Is.EqualTo(0));
+            Assert.That(first.Value, Is.EqualTo("start-ABCD-end"));
         }
 
         [Test]
@@ -921,23 +921,26 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(3, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(3));
             Assert.IsTrue(ies.InputElements.Any(x => x.Definition == implicitA));
             Assert.IsTrue(ies.InputElements.Any(x => x.Definition == implicitAb));
             Assert.IsTrue(ies.InputElements.Any(x => x.Definition == implicitAbc));
             token = ies.InputElements.First(x => x.Definition == implicitA);
-            Assert.AreEqual(1, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(0, 1, 1), token.StartPosition);
-            Assert.AreEqual("a", token.Value);
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(1));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(0, 1, 1)));
+            Assert.That(token.Value, Is.EqualTo("a"));
             token = ies.InputElements.First(x => x.Definition == implicitAb);
-            Assert.AreEqual(2, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(0, 1, 1), token.StartPosition);
-            Assert.AreEqual("ab", token.Value);
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(2));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(0, 1, 1)));
+            Assert.That(token.Value, Is.EqualTo("ab"));
             token = ies.InputElements.First(x => x.Definition == implicitAbc);
-            Assert.AreEqual(3, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(0, 1, 1), token.StartPosition);
-            Assert.AreEqual("abc", token.Value);
-            Assert.AreEqual(1, tokenizer.CurrentPosition.Index);
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(3));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(0, 1, 1)));
+            Assert.That(token.Value, Is.EqualTo("abc"));
+            Assert.That(tokenizer.CurrentPosition.Index, Is.EqualTo(1));
             Assert.IsFalse(tokenizer.IsAtEnd);
 
             // action
@@ -948,18 +951,20 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(2, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(2));
             Assert.IsTrue(ies.InputElements.Any(x => x.Definition == implicitBc));
             Assert.IsTrue(ies.InputElements.Any(x => x.Definition == implicitBca));
             token = ies.InputElements.First(x => x.Definition == implicitBc);
-            Assert.AreEqual(3, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(1, 1, 2), token.StartPosition);
-            Assert.AreEqual("bc", token.Value);
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(3));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(1, 1, 2)));
+            Assert.That(token.Value, Is.EqualTo("bc"));
             token = ies.InputElements.First(x => x.Definition == implicitBca);
-            Assert.AreEqual(4, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(1, 1, 2), token.StartPosition);
-            Assert.AreEqual("bca", token.Value);
-            Assert.AreEqual(2, tokenizer.CurrentPosition.Index);
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(4));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(1, 1, 2)));
+            Assert.That(token.Value, Is.EqualTo("bca"));
+            Assert.That(tokenizer.CurrentPosition.Index, Is.EqualTo(2));
             Assert.IsFalse(tokenizer.IsAtEnd);
 
             // action
@@ -970,18 +975,20 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(2, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(2));
             Assert.IsTrue(ies.InputElements.Any(x => x.Definition == implicitC));
             Assert.IsTrue(ies.InputElements.Any(x => x.Definition == implicitCab));
             token = ies.InputElements.First(x => x.Definition == implicitC);
-            Assert.AreEqual(3, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(2, 1, 3), token.StartPosition);
-            Assert.AreEqual("c", token.Value);
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(3));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(2, 1, 3)));
+            Assert.That(token.Value, Is.EqualTo("c"));
             token = ies.InputElements.First(x => x.Definition == implicitCab);
-            Assert.AreEqual(5, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(2, 1, 3), token.StartPosition);
-            Assert.AreEqual("cab", token.Value);
-            Assert.AreEqual(3, tokenizer.CurrentPosition.Index);
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(5));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(2, 1, 3)));
+            Assert.That(token.Value, Is.EqualTo("cab"));
+            Assert.That(tokenizer.CurrentPosition.Index, Is.EqualTo(3));
             Assert.IsFalse(tokenizer.IsAtEnd);
 
             // action
@@ -992,23 +999,26 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(3, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(3));
             Assert.IsTrue(ies.InputElements.Any(x => x.Definition == implicitA));
             Assert.IsTrue(ies.InputElements.Any(x => x.Definition == implicitAb));
             Assert.IsTrue(ies.InputElements.Any(x => x.Definition == implicitAbc));
             token = ies.InputElements.First(x => x.Definition == implicitA);
-            Assert.AreEqual(4, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(3, 1, 4), token.StartPosition);
-            Assert.AreEqual("a", token.Value);
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(4));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(3, 1, 4)));
+            Assert.That(token.Value, Is.EqualTo("a"));
             token = ies.InputElements.First(x => x.Definition == implicitAb);
-            Assert.AreEqual(5, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(3, 1, 4), token.StartPosition);
-            Assert.AreEqual("ab", token.Value);
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(5));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(3, 1, 4)));
+            Assert.That(token.Value, Is.EqualTo("ab"));
             token = ies.InputElements.First(x => x.Definition == implicitAbc);
-            Assert.AreEqual(6, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(3, 1, 4), token.StartPosition);
-            Assert.AreEqual("abc", token.Value);
-            Assert.AreEqual(4, tokenizer.CurrentPosition.Index);
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(6));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(3, 1, 4)));
+            Assert.That(token.Value, Is.EqualTo("abc"));
+            Assert.That(tokenizer.CurrentPosition.Index, Is.EqualTo(4));
             Assert.IsFalse(tokenizer.IsAtEnd);
 
             // action
@@ -1019,13 +1029,14 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             token = ies.InputElements.First();
-            Assert.AreSame(implicitBc, token.Definition);
-            Assert.AreEqual(6, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(4, 1, 5), token.StartPosition);
-            Assert.AreEqual("bc", token.Value);
-            Assert.AreEqual(5, tokenizer.CurrentPosition.Index);
+            Assert.That(token.Definition, Is.SameAs(implicitBc));
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(6));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(4, 1, 5)));
+            Assert.That(token.Value, Is.EqualTo("bc"));
+            Assert.That(tokenizer.CurrentPosition.Index, Is.EqualTo(5));
             Assert.IsFalse(tokenizer.IsAtEnd);
 
             // action
@@ -1036,13 +1047,14 @@ namespace MetaphysicsIndustries.Giza.Test
             Assert.IsNotNull(ies.Errors);
             Assert.IsEmpty(ies.Errors);
             Assert.IsNotNull(ies.InputElements);
-            Assert.AreEqual(1, ies.InputElements.Count());
+            Assert.That(ies.InputElements.Count(), Is.EqualTo(1));
             token = ies.InputElements.First();
-            Assert.AreSame(implicitC, token.Definition);
-            Assert.AreEqual(6, token.IndexOfNextTokenization);
-            Assert.AreEqual(new InputPosition(5, 1, 6), token.StartPosition);
-            Assert.AreEqual("c", token.Value);
-            Assert.AreEqual(6, tokenizer.CurrentPosition.Index);
+            Assert.That(token.Definition, Is.SameAs(implicitC));
+            Assert.That(token.IndexOfNextTokenization, Is.EqualTo(6));
+            Assert.That(token.StartPosition,
+                Is.EqualTo(new InputPosition(5, 1, 6)));
+            Assert.That(token.Value, Is.EqualTo("c"));
+            Assert.That(tokenizer.CurrentPosition.Index, Is.EqualTo(6));
             Assert.IsTrue(tokenizer.IsAtEnd);
 
 

--- a/check_code_style.sh
+++ b/check_code_style.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# MetaphysicsIndustries.Giza - A Parsing System
+# Copyright (C) 2008-2021 Metaphysics Industries, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+# USA
+
+echo ""
+echo "Long lines:"
+
+#grep -n '................................................................................' $(find . -name \*.cs)
+git diff -U0 | \
+    grep -v -e '^@@' -e '^diff --git' -e '^+++' -e '^---' -e '^-' | \
+    grep -n '[-+]................................................................................'
+#                12345678901234567890123456789012345678901234567890123456789012345678901234567890
+git diff --cached -U0 | \
+    grep -v -e '^@@' -e '^diff --git' -e '^+++' -e '^---' -e '^-' | \
+    grep -n '[-+]................................................................................'
+#                12345678901234567890123456789012345678901234567890123456789012345678901234567890
+
+echo ""
+echo "Trailing whitespace:"
+
+git diff -U0 | \
+    grep -v -e '^@@' -e '^diff --git' -e '^+++' -e '^---' -e '^-' | \
+    grep -n '[ 	]$'  # space or literal tab
+git diff --cached -U0 | \
+    grep -v -e '^@@' -e '^diff --git' -e '^+++' -e '^---' -e '^-' | \
+    grep -n '[ 	]$'  # space or literal tab
+#grep -rnE '[ 	]$' \
+# $(git ls-files | grep -v -e 'solus/getline.cs' -e 'solus/NDesk.Options.cs')
+
+# TODO: check for tabs rather than spaces
+# TODO: check for trailing whitespace on lines
+# TODO: check for single newline at end of file
+# TODO: count TODO's
+
+echo ""
+echo "Files missing license notices:"
+grep -L 'GNU Lesser General Public' \
+    $(find . -name \*.cs -o -name \*.sh -o -name \*.giza |
+        grep -v -e '^./solus/NDesk' -e '^./solus/getline' -e '^./obj/' \
+            -e '^./solus/obj/' -e '^./MetaphysicsIndustries.Solus.Test/obj/' )


### PR DESCRIPTION
This PR changes the tests to use a constraint model, so as to get rid of a large number of warnings that resulted from the updated nunit version.